### PR TITLE
add logout button

### DIFF
--- a/header.php
+++ b/header.php
@@ -14,7 +14,8 @@ db_databaseConnect();
 $pages = array("Broadcast" => "broadcast.php", 
     "Hotline" => "hotline_staff.php",
     "Call / Text" => "contact.php", 
-    "Log" => "log.php");
+    "Log" => "log.php",
+    "Logout" => "javascript:logout();");
 
 ?>
 <!DOCTYPE html>
@@ -36,6 +37,32 @@ $pages = array("Broadcast" => "broadcast.php",
 
 <!-- Custom styles for this template -->
     <link href="dashboard.css" rel="stylesheet">
+
+<script>
+  // reference: http://stackoverflow.com/questions/233507/how-to-log-out-user-from-web-site-using-basic-authentication
+  function logout() {
+    var outcome, u, m = "You should be logged out now."
+    // IE has a simple solution for it - API:
+    try { outcome = document.execCommand("ClearAuthenticationCache") }catch(e){}
+    // Other browsers need a larger solution - AJAX call with special user name - 'logout'.
+    if (!outcome) {
+      outcome = (function(x){
+        if (x) {
+          x.open("HEAD", location.href, true, "logout", (new Date()).getTime().toString())
+          x.send("")
+          return 1
+        } else {
+          return
+        }
+      })(window.XMLHttpRequest ? new window.XMLHttpRequest() : ( window.ActiveXObject ? new ActiveXObject("Microsoft.XMLHTTP") : u ))
+    }
+    if (!outcome) {
+      m = "Your browser doesn't support log out functionality. Close all windows and restart the browser."
+    }
+    alert(m)
+    window.location = location.href
+  }
+</script>
 
 </head>
 <body>


### PR DESCRIPTION
Ok, so this is kind of a hack, but it doesn't look like there's an alternative, aside from not using http basic auth, which doesn't really have any logout functionality. The closest thing is (ironically) an IE-specific directive (called ClearAuthenticationCache). For everything else, you basically need to send known-bad credentials in order for the browser to (ideally) forget the good ones.

We can't really just point to URL like `http://fake_username:fake_password@example.com` either, because the handling of this is likely to be deprecated and/or ignored. I think the current version of Chrome already ignore this entirely. If attempted on the current version of Safari, you get a giant red "Phishing Attempt Warning" screen, which is definitely not something we want.

Anyway, this solution seems to work as well as could be expected. This is done by first trying the IE directive, then creating an AJAX request to the current URL using the fake username "logout" and a fake password based on the current time stamp. After being clicked, a dialog pops up saying you've been logged out. When you dismiss it, the page is reloaded and the auth dialog will pop up again. If you cancel, you'll see the expected 401 error. You can press the back button, but you can't reload or make any new requests without being asked to re-auth. Seems alright to me.

Tested in Safari 10.1, Chrome 57, Firefox 53, and Opera 44 (all on a Mac) and they all show the same expected behavior.