### PR TITLE
Fix sms send error

### DIFF
--- a/call/voice.php
+++ b/call/voice.php
@@ -32,7 +32,7 @@ if (isset($_REQUEST['To']) && strlen($_REQUEST['To']) > 0) {
         $dial->client($number);
     }
 } else {
-    $response->say("Thanks for calling!");
+    sms_playOrSay($response, "Thanks for calling!");
 }
 
 header('Content-Type: text/xml');

--- a/database_schema.sql
+++ b/database_schema.sql
@@ -116,6 +116,7 @@ CREATE TABLE `languages` (
   `language` varchar(25) NOT NULL,
   `keypress` int(1) UNSIGNED NOT NULL,
   `prompt` varchar(255) NOT NULL,
+  `promt_media_url` varchar(255) NOT NULL,
   `voicemail` varchar(255) NOT NULL DEFAULT '',
   `voicemail_received` varchar(255) NOT NULL DEFAULT '',
   `twilio_code` varchar(15) NOT NULL

--- a/database_schema.sql
+++ b/database_schema.sql
@@ -9,19 +9,6 @@ SET time_zone = "+00:00";
 -- --------------------------------------------------------
 
 --
--- Table structure for table `blocked_numbers`
---
-
-CREATE TABLE `blocked_numbers` (
-  `id` int(11) UNSIGNED NOT NULL,
-  `phone` varchar(25) NOT NULL,
-  `added` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 COMMENT='List of blocked numbers.';
-
-
--- --------------------------------------------------------
-
---
 -- Table structure for table `broadcast`
 --
 
@@ -114,33 +101,23 @@ CREATE TABLE `errors` (
 CREATE TABLE `languages` (
   `id` int(11) UNSIGNED NOT NULL,
   `language` varchar(25) NOT NULL,
-  `keypress` int(1) UNSIGNED NOT NULL,
   `prompt` varchar(255) NOT NULL,
-  `promt_media_url` varchar(255) NOT NULL,
   `voicemail` varchar(255) NOT NULL DEFAULT '',
   `voicemail_received` varchar(255) NOT NULL DEFAULT '',
   `twilio_code` varchar(15) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 COMMENT='Languages the hotline supports';
 
-
 --
 -- Dumping data for table `languages`
 --
 
-INSERT INTO `languages` (`id`, `language`, `keypress`, `prompt`, `voicemail`, `voicemail_received`, `twilio_code`) VALUES
-(1, 'English', 2, 'Press 2 for English.', 'No one is available to answer.  Please leave a message.', 'Your voicemail has been received.  Goodbye.', 'en-US'),
-(2, 'Spanish', 1, 'Para espa&#241;ol oprima uno.', 'Nadie esta disponible. Favor de dejar un mensaje.', 'Tu correo de voz se ha recibido. Adi&oacute;s.', 'es-MX');
+INSERT INTO `languages` (`id`, `language`, `prompt`, `voicemail`, `voicemail_received`, `twilio_code`) VALUES
+(1, 'English', 'Press 1 for English.', 'No one is available to answer.  Please leave a message.', 'Your voicemail has been received.  Goodbye.', 'en-US'),
+(2, 'Spanish', 'Para espa&#241;ol oprima dos.', 'Nadie esta disponible. Favor de dejar un mensaje.', 'Tu correo de voz se ha recibido. Adi&oacute;s.', 'es-MX');
 
 --
 -- Indexes for dumped tables
 --
-
---
--- Indexes for table `blocked_numbers`
---
-ALTER TABLE `blocked_numbers`
-  ADD PRIMARY KEY (`id`),
-  ADD UNIQUE KEY `phone` (`phone`);
 
 --
 -- Indexes for table `broadcast`
@@ -192,40 +169,35 @@ ALTER TABLE `languages`
 --
 
 --
--- AUTO_INCREMENT for table `blocked_numbers`
---
-ALTER TABLE `blocked_numbers`
-  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT;
---
 -- AUTO_INCREMENT for table `broadcast`
 --
 ALTER TABLE `broadcast`
-  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT;
+  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=24;
 --
 -- AUTO_INCREMENT for table `broadcast_responses`
 --
 ALTER TABLE `broadcast_responses`
-  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT;
+  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=11;
 --
 -- AUTO_INCREMENT for table `call_times`
 --
 ALTER TABLE `call_times`
-  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT;
+  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=34;
 --
 -- AUTO_INCREMENT for table `communications`
 --
 ALTER TABLE `communications`
-  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT;
+  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=358;
 --
 -- AUTO_INCREMENT for table `contacts`
 --
 ALTER TABLE `contacts`
-  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT;
+  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=17;
 --
 -- AUTO_INCREMENT for table `errors`
 --
 ALTER TABLE `errors`
-  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT;
+  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=12;
 --
 -- AUTO_INCREMENT for table `languages`
 --
@@ -241,5 +213,3 @@ ALTER TABLE `languages`
 ALTER TABLE `call_times`
   ADD CONSTRAINT `call_times_ibfk_1` FOREIGN KEY (`contact_id`) REFERENCES `contacts` (`id`),
   ADD CONSTRAINT `call_times_ibfk_2` FOREIGN KEY (`language_id`) REFERENCES `languages` (`id`);
-
-COMMIT;

--- a/database_schema.sql
+++ b/database_schema.sql
@@ -9,6 +9,19 @@ SET time_zone = "+00:00";
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `blocked_numbers`
+--
+
+CREATE TABLE `blocked_numbers` (
+  `id` int(11) UNSIGNED NOT NULL,
+  `phone` varchar(25) NOT NULL,
+  `added` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 COMMENT='List of blocked numbers.';
+
+
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `broadcast`
 --
 
@@ -101,23 +114,32 @@ CREATE TABLE `errors` (
 CREATE TABLE `languages` (
   `id` int(11) UNSIGNED NOT NULL,
   `language` varchar(25) NOT NULL,
+  `keypress` int(1) UNSIGNED NOT NULL,
   `prompt` varchar(255) NOT NULL,
   `voicemail` varchar(255) NOT NULL DEFAULT '',
   `voicemail_received` varchar(255) NOT NULL DEFAULT '',
   `twilio_code` varchar(15) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 COMMENT='Languages the hotline supports';
 
+
 --
 -- Dumping data for table `languages`
 --
 
-INSERT INTO `languages` (`id`, `language`, `prompt`, `voicemail`, `voicemail_received`, `twilio_code`) VALUES
-(1, 'English', 'Press 1 for English.', 'No one is available to answer.  Please leave a message.', 'Your voicemail has been received.  Goodbye.', 'en-US'),
-(2, 'Spanish', 'Para espa&#241;ol oprima dos.', 'Nadie esta disponible. Favor de dejar un mensaje.', 'Tu correo de voz se ha recibido. Adi&oacute;s.', 'es-MX');
+INSERT INTO `languages` (`id`, `language`, `keypress`, `prompt`, `voicemail`, `voicemail_received`, `twilio_code`) VALUES
+(1, 'English', 2, 'Press 2 for English.', 'No one is available to answer.  Please leave a message.', 'Your voicemail has been received.  Goodbye.', 'en-US'),
+(2, 'Spanish', 1, 'Para espa&#241;ol oprima uno.', 'Nadie esta disponible. Favor de dejar un mensaje.', 'Tu correo de voz se ha recibido. Adi&oacute;s.', 'es-MX');
 
 --
 -- Indexes for dumped tables
 --
+
+--
+-- Indexes for table `blocked_numbers`
+--
+ALTER TABLE `blocked_numbers`
+  ADD PRIMARY KEY (`id`),
+  ADD UNIQUE KEY `phone` (`phone`);
 
 --
 -- Indexes for table `broadcast`
@@ -169,35 +191,40 @@ ALTER TABLE `languages`
 --
 
 --
+-- AUTO_INCREMENT for table `blocked_numbers`
+--
+ALTER TABLE `blocked_numbers`
+  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT;
+--
 -- AUTO_INCREMENT for table `broadcast`
 --
 ALTER TABLE `broadcast`
-  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=24;
+  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT;
 --
 -- AUTO_INCREMENT for table `broadcast_responses`
 --
 ALTER TABLE `broadcast_responses`
-  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=11;
+  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT;
 --
 -- AUTO_INCREMENT for table `call_times`
 --
 ALTER TABLE `call_times`
-  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=34;
+  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT;
 --
 -- AUTO_INCREMENT for table `communications`
 --
 ALTER TABLE `communications`
-  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=358;
+  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT;
 --
 -- AUTO_INCREMENT for table `contacts`
 --
 ALTER TABLE `contacts`
-  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=17;
+  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT;
 --
 -- AUTO_INCREMENT for table `errors`
 --
 ALTER TABLE `errors`
-  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=12;
+  MODIFY `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT;
 --
 -- AUTO_INCREMENT for table `languages`
 --
@@ -213,3 +240,5 @@ ALTER TABLE `languages`
 ALTER TABLE `call_times`
   ADD CONSTRAINT `call_times_ibfk_1` FOREIGN KEY (`contact_id`) REFERENCES `contacts` (`id`),
   ADD CONSTRAINT `call_times_ibfk_2` FOREIGN KEY (`language_id`) REFERENCES `languages` (`id`);
+
+COMMIT;

--- a/lib/lib_sms.php
+++ b/lib/lib_sms.php
@@ -83,6 +83,11 @@ function sms_send($numbers, $text, &$error, $from = '', $progress_every = 0)
 {
 	global $TWILIO_ACCOUNT_SID, $TWILIO_AUTH_TOKEN, $HOTLINE_CALLER_ID;
 	
+	if (!count($numbers)) {
+		// there are no messages to send
+		return true;
+	}
+	
 	if ($progress_every) {
 		echo '<p>Sending ';
 	}

--- a/lib/lib_sms.php
+++ b/lib/lib_sms.php
@@ -839,11 +839,13 @@ function sms_isNumberBlocked($phone, &$error)
 *
 * ...
 * 
-* @param string $media
-*   The queue's to retrieve's "friendlyName"
+* @param string $gather
+*   The twilio object to call say or play from
+* @param string $string
+*   A string of text which could be a URL which either makes a robot voice say the string or twilio play the URL 
+* @param string $voice_code
+*   The String for the twilio voice code which indicates which language the text is 
 *
-* @return bool
-*   True unless an error occurred
 */
 
 function sms_playOrSay(&$gather, $string, $voice_code = null)
@@ -851,7 +853,7 @@ function sms_playOrSay(&$gather, $string, $voice_code = null)
     if (filter_var($string, FILTER_VALIDATE_URL) === TRUE) {
         $gather->play($string);
     } else {
-        if (!$voice_code) $voice_code = 'en';
+        if (!$voice_code) $voice_code = 'en-US';
         $gather->say($string,
 		array('voice' => 'alice', 'language' => $voice_code));
     }

--- a/lib/lib_sms.php
+++ b/lib/lib_sms.php
@@ -834,4 +834,26 @@ function sms_isNumberBlocked($phone, &$error)
 	return ($count > 0);
 }
 
+/**
+* Based on the media string either says the string in a robot voice or plays the url in the string
+*
+* ...
+* 
+* @param string $media
+*   The queue's to retrieve's "friendlyName"
+*
+* @return bool
+*   True unless an error occurred
+*/
+
+function sms_playOrSay(&$gather, $media, $voice_code)
+{
+    if (filter_var($url, FILTER_VALIDATE_URL) === TRUE) {
+        $gather->play($media);
+    } else {
+        $gather->say($media,
+		array('voice' => 'alice', 'language' => $voice_code));
+    }
+}
+
 ?>

--- a/lib/lib_sms.php
+++ b/lib/lib_sms.php
@@ -846,13 +846,13 @@ function sms_isNumberBlocked($phone, &$error)
 *   True unless an error occurred
 */
 
-function sms_playOrSay(&$gather, $media, $voice_code = null)
+function sms_playOrSay(&$gather, $string, $voice_code = null)
 {
-    if (filter_var($url, FILTER_VALIDATE_URL) === TRUE) {
-        $gather->play($media);
+    if (filter_var($string, FILTER_VALIDATE_URL) === TRUE) {
+        $gather->play($string);
     } else {
         if (!$voice_code) $voice_code = 'en';
-        $gather->say($media,
+        $gather->say($string,
 		array('voice' => 'alice', 'language' => $voice_code));
     }
 }

--- a/lib/lib_sms.php
+++ b/lib/lib_sms.php
@@ -846,11 +846,12 @@ function sms_isNumberBlocked($phone, &$error)
 *   True unless an error occurred
 */
 
-function sms_playOrSay(&$gather, $media, $voice_code)
+function sms_playOrSay(&$gather, $media, $voice_code = null)
 {
     if (filter_var($url, FILTER_VALIDATE_URL) === TRUE) {
         $gather->play($media);
     } else {
+        if (!$voice_code) $voice_code = 'en';
         $gather->say($media,
 		array('voice' => 'alice', 'language' => $voice_code));
     }

--- a/lib/lib_sms.php
+++ b/lib/lib_sms.php
@@ -850,7 +850,8 @@ function sms_isNumberBlocked($phone, &$error)
 
 function sms_playOrSay(&$gather, $string, $voice_code = null)
 {
-    if (filter_var($string, FILTER_VALIDATE_URL) === TRUE) {
+    $sub_string = substr($string, 0, 4);
+    if ($sub_string == 'http') {
         $gather->play($string);
     } else {
         if (!$voice_code) $voice_code = 'en-US';

--- a/twin/handle-screen.php
+++ b/twin/handle-screen.php
@@ -25,7 +25,7 @@ if ($user_pushed == 1) {
 		// yes, connect them
 		
 		// announce the connection
-		$response->say($HOTLINE_CONNECTING_TO_CALLER, array('voice' => 'alice'));
+		sms_playOrSay($gather, $HOTLINE_CONNECTING_TO_CALLER);
 		
 		// connect them to the caller at the front of the queue and log it
 		$dial = $response->dial();
@@ -37,11 +37,11 @@ if ($user_pushed == 1) {
 		// TODO
 		
 		// no, let them know the caller hung up
-		$response->say($HOTLINE_CALLER_HUNG_UP, array('voice' => 'alice'));
+		sms_playOrSay($response, $HOTLINE_CALLER_HUNG_UP);
 	}
 } else {
 	// no, say goodbye
-    $response->say($HOTLINE_GOODBYE, array('voice' => 'alice'));
+    sms_playOrSay($response, $HOTLINE_GOODBYE);
 }
 $response->hangup();
 

--- a/twin/handle-screen.php
+++ b/twin/handle-screen.php
@@ -25,7 +25,7 @@ if ($user_pushed == 1) {
 		// yes, connect them
 		
 		// announce the connection
-		sms_playOrSay($gather, $HOTLINE_CONNECTING_TO_CALLER);
+		sms_playOrSay($response, $HOTLINE_CONNECTING_TO_CALLER);
 		
 		// connect them to the caller at the front of the queue and log it
 		$dial = $response->dial();

--- a/twin/incoming-voice.php
+++ b/twin/incoming-voice.php
@@ -38,13 +38,7 @@ $gather->say($HOTLINE_INTRO,
 
 // and each of the language options
 foreach ($languages as $language) {
-    if ($language['prompt_media_url']) {
-        $gather->play($language['prompt_media_url']);
-    } else {
-        $gather->say($language['prompt'],
-		array('voice' => 'alice', 'language' => $language['twilio_code'])
-    );
-    }
+    sms_playOrSay($gather, $language['prompt'], language['twilio_code']);
 }
 
 $gather->say($HOTLINE_STRAIGHT_TO_VOICEMAIL, array('voice' => 'alice'));

--- a/twin/incoming-voice.php
+++ b/twin/incoming-voice.php
@@ -38,9 +38,13 @@ $gather->say($HOTLINE_INTRO,
 
 // and each of the language options
 foreach ($languages as $language) {
-	$gather->say($language['prompt'],
+    if ($language['prompt_media_url']) {
+        $gather->play($language['prompt_media_url']);
+    } else {
+        $gather->say($language['prompt'],
 		array('voice' => 'alice', 'language' => $language['twilio_code'])
-	);
+    );
+    }
 }
 
 $gather->say($HOTLINE_STRAIGHT_TO_VOICEMAIL, array('voice' => 'alice'));

--- a/twin/incoming-voice.php
+++ b/twin/incoming-voice.php
@@ -32,16 +32,14 @@ $gather = $response->gather(array(
 );
 
 // say the hotline intro
-$gather->say($HOTLINE_INTRO,
-	array('voice' => 'alice')
-);
+sms_playOrSay($gather, $HOTLINE_INTRO);
 
 // and each of the language options
 foreach ($languages as $language) {
     sms_playOrSay($gather, $language['prompt'], language['twilio_code']);
 }
 
-$gather->say($HOTLINE_STRAIGHT_TO_VOICEMAIL, array('voice' => 'alice'));
+sms_playOrSay($gather, $HOTLINE_STRAIGHT_TO_VOICEMAIL);
 
 // and handle a timeout
 $response->redirect('incoming-voice-dial.php?Digits=TIMEOUT',

--- a/twin/incoming-voice.php
+++ b/twin/incoming-voice.php
@@ -36,7 +36,7 @@ sms_playOrSay($gather, $HOTLINE_INTRO);
 
 // and each of the language options
 foreach ($languages as $language) {
-    sms_playOrSay($gather, $language['prompt'], language['twilio_code']);
+    sms_playOrSay($gather, $language['prompt'], $language['twilio_code']);
 }
 
 sms_playOrSay($gather, $HOTLINE_STRAIGHT_TO_VOICEMAIL);

--- a/twin/screen-call.php
+++ b/twin/screen-call.php
@@ -28,8 +28,7 @@ $gather = $response->gather(array(
 );
 
 // say the hotline staff prompt
-$gather->say($HOTLINE_STAFF_PROMPT_1 . $language['language'] . $HOTLINE_STAFF_PROMPT_2,
-	array('voice' => 'alice')
+sms_playOrSay($gather, $HOTLINE_STAFF_PROMPT_1 . $language['language'] . $HOTLINE_STAFF_PROMPT_2
 );
 
 // hang up if it times out

--- a/twin/voicemail-record.php
+++ b/twin/voicemail-record.php
@@ -30,18 +30,14 @@ sms_loadLanguageById($language_id, $language, $error);
 
 if (!$url) {
 	// no voicemail!
-	$response->sms_playOrSay('An error occurred - your voicemail was not received. Goodbye.',
-		array('voice' => 'alice')
-	);
+	sms_playOrSay($response, 'An error occurred - your voicemail was not received. Goodbye.');
 } else {
 	// send an text alerting the volunteers of a voicemail
 	if (!alertVolunteersOfVoicemail($from, $url, $duration, $error)) {
-		$response->sms_playOrSay('An error occurred - your voicemail was not received. Goodbye.');
+		sms_playOrSay($response, 'An error occurred - your voicemail was not received. Goodbye.');
 	} else {
 		// voicemail was received successfully
-		$response->sms_playOrSay($language['voicemail_received'],
-			array('voice' => 'alice', 'language' => $language['twilio_code'])
-		);
+		sms_playOrSay($response, $language['voicemail_received'], $language['twilio_code']);
 	}
 }	
 

--- a/twin/voicemail-record.php
+++ b/twin/voicemail-record.php
@@ -30,18 +30,16 @@ sms_loadLanguageById($language_id, $language, $error);
 
 if (!$url) {
 	// no voicemail!
-	$response->say('An error occurred - your voicemail was not received. Goodbye.',
+	$response->sms_playOrSay('An error occurred - your voicemail was not received. Goodbye.',
 		array('voice' => 'alice')
 	);
 } else {
 	// send an text alerting the volunteers of a voicemail
 	if (!alertVolunteersOfVoicemail($from, $url, $duration, $error)) {
-		$response->say('An error occurred - your voicemail was not received. Goodbye.',
-			array('voice' => 'alice')
-		);
+		$response->sms_playOrSay('An error occurred - your voicemail was not received. Goodbye.');
 	} else {
 		// voicemail was received successfully
-		$response->say($language['voicemail_received'],
+		$response->sms_playOrSay($language['voicemail_received'],
 			array('voice' => 'alice', 'language' => $language['twilio_code'])
 		);
 	}

--- a/twin/voicemail.php
+++ b/twin/voicemail.php
@@ -22,9 +22,7 @@ sms_loadLanguageById($language_id, $language, $error);
 
 // no one available to answer
 if ($language_id != 0) {
-    $response->say($language['voicemail'], 
-        array('voice' => 'alice', 'language' => $language['twilio_code'])
-    );
+    sms_playOrSay($response, $language['voicemail'], $language['twilio_code']);
 }
 
 // record for up to 5 minutes
@@ -36,9 +34,7 @@ $response->record(
 );
 
 // if we reach here, then the recording did not succeed
-$response->say('An error occurred - your message was not received.',
-	array('voice' => 'alice')
-);
+sms_playOrSay($response, 'An error occurred - your message was not received.');
 
 echo $response;
 


### PR DESCRIPTION
sms_send() was returning false if an empty array of numbers was pass to it.  This meant that if someone sent a text to the hotline, and there was no one on duty, it would reply with "Unable to forward your text".