### PR TITLE
Fix error in sms_send()

### DIFF
--- a/lib/lib_sms.php
+++ b/lib/lib_sms.php
@@ -83,6 +83,11 @@ function sms_send($numbers, $text, &$error, $from = '', $progress_every = 0)
 {
 	global $TWILIO_ACCOUNT_SID, $TWILIO_AUTH_TOKEN, $HOTLINE_CALLER_ID;
 	
+	if (!count($numbers)) {
+		// there are no messages to send
+		return true;
+	}
+	
 	if ($progress_every) {
 		echo '<p>Sending ';
 	}


### PR DESCRIPTION
sms_send() was returning false when an empty array of $numbers was passed to it. This was causing a reply of "Unable to forward your text" when someone texted the hotline if no one was on duty.