### PR TITLE
Choice for receiving calls, texts and call answered alerts; add call time modal dialog

### DIFF
--- a/database_schema.sql
+++ b/database_schema.sql
@@ -56,6 +56,8 @@ CREATE TABLE `call_times` (
   `earliest` time NOT NULL,
   `latest` time NOT NULL,
   `receive_texts` enum('y','n') NOT NULL DEFAULT 'y',
+  `receive_calls` enum('y','n') NOT NULL DEFAULT 'y',
+  `receive_call_answered_alerts` enum('y','n') NOT NULL DEFAULT 'n',
   `language_id` int(11) UNSIGNED NOT NULL DEFAULT '0',
   `enabled` enum('y','n') NOT NULL DEFAULT 'y'
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 COMMENT='Defines days and times that a volunteer will be called.';

--- a/hotline_staff.php
+++ b/hotline_staff.php
@@ -503,8 +503,8 @@ function addStaff($staff, &$error, &$message)
 *   Call time form data.  Contains the following keys:
 *		'id' => The contact id to add a call time to
 * 		'day' => 'all','weekdays','weekends','Sun','Mon','Tue','Wed','Thu','Fri','Sat'
-* 		'earliest_time' => The earliest time the contact should be called.
-*		'latest_time' => The latest time the contact should be called.
+* 		'earliest' => The earliest time the contact should be called.
+*		'latest' => The latest time the contact should be called.
 *		'language_id' => The supported language.
 *		'texts' => Whether the contact should receive texts.
 *		'calls' => Whether the contact should receive calls.
@@ -537,12 +537,12 @@ function addCallTime($call_time, &$error, &$message)
 		$call_time['day'] = 'all';
 	}
 	// default earliest time
-	if (!$call_time['earliest_time']) {
-		$call_time['earliest_time'] = '12:00 am';
+	if (!$call_time['earliest']) {
+		$call_time['earliest'] = '12:00 am';
 	}
 	// default latest time
-	if (!$call_time['latest_time']) {
-		$call_time['latest_time'] = '11:59 pm';
+	if (!$call_time['latest']) {
+		$call_time['latest'] = '11:59 pm';
 	}
 	// language id
 	$call_time['language_id'] = (int)$call_time['language_id'];
@@ -555,8 +555,8 @@ function addCallTime($call_time, &$error, &$message)
 	$sql = "INSERT INTO call_times SET ".
 		"contact_id='".addslashes($call_time['id'])."',".
 		"day='".addslashes($call_time['day'])."',".
-		"earliest='".addslashes(date("H:i:s", strtotime($call_time['earliest_time'])))."',".
-		"latest='".addslashes(date("H:i:s", strtotime($call_time['latest_time'])))."',".
+		"earliest='".addslashes(date("H:i:s", strtotime($call_time['earliest'])))."',".
+		"latest='".addslashes(date("H:i:s", strtotime($call_time['latest'])))."',".
 		"language_id='".addslashes($call_time['language_id'])."',".
 		"receive_texts='". (($call_time['texts'] == 'on') ? 'y' : 'n') . "',".
 		"receive_calls='". (($call_time['calls'] == 'on') ? 'y' : 'n') . "',".

--- a/hotline_staff.php
+++ b/hotline_staff.php
@@ -5,8 +5,6 @@
 *
 * Display and edit hotline staff on duty now, and all staff
 * 
-* TO-DO: add database schema changes, check for call forwarding, implement call answer alerts
-* 
 */
 
 require_once 'config.php';

--- a/lib/lib_sms.php
+++ b/lib/lib_sms.php
@@ -29,8 +29,6 @@ use Twilio\Twiml;
 *   An array of boolean values, with keys 'calls', 'texts' and 'answered_alerts'.  If
 *   these are set to true, then only contacts that support receiving these will be
 *   returned.
-* @param bool $calls
-*   If true, the contact must support calls.
 * @param string &$error
 *   An error if one occurred.
 *   

--- a/lib/lib_sms.php
+++ b/lib/lib_sms.php
@@ -76,8 +76,6 @@ function sms_getActiveContacts(&$contacts, $language_id, $receives, &$error)
 *   An error if one occurred.
 * @param string $from = ''
 *   The number to send from.  Defaults to the $HOTLINE_CALLER_ID constant.
-* @param string $from = ''
-*   The number to send from.  Defaults to the $HOTLINE_CALLER_ID constant.
 * @param int $progress_every = 0
 *   If nonzero, displays a progress mark after this many messages are sent.
 *   

--- a/twin/incoming-sms.php
+++ b/twin/incoming-sms.php
@@ -97,8 +97,9 @@ function processHotlineText($from, $body, &$message, &$error)
 	$error = '';
 	$from_descriptive = $from;
 	
-    // look up who is on duty
-	sms_getActiveContacts($contacts, 0 /* no language restriction */, true /* texting */, $error);
+    // look up who is on duty and receive texts
+    $receives = array('calls' => false, 'texts' => true, 'answered_alerts' => false);
+	sms_getActiveContacts($contacts, 0 /* no language restriction */, $receives, $error);
 
 	// format the numbers
 	$numbers = array();

--- a/twin/incoming-voice-dial.php
+++ b/twin/incoming-voice-dial.php
@@ -90,8 +90,9 @@ function getNumbersToCall($from, $language_id, &$enqueue_anyway, &$numbers, &$er
 	$call_anyway = false;
 	$numbers = array();
 	
-	// who should we call given the current day, time and language?
-	if (!sms_getActiveContacts($contacts, $language_id, false /* not texting */, $error)) {
+	// whom should we call given the current day, time and language?
+	$receives = array('calls' => true, 'texts' => false, 'answered_alerts' => false);
+	if (!sms_getActiveContacts($contacts, $language_id, $receives, $error)) {
 		return false;
 	}
 

--- a/twin/log-queue.php
+++ b/twin/log-queue.php
@@ -3,7 +3,8 @@
 * @file
 * Log the bridging of a caller to staff
 *
-* 
+* Send an alert to those who receive call answered alerts.
+*  
 */
 
 require_once '../config.php';
@@ -19,10 +20,77 @@ $_REQUEST['status'] = 'call answered';
 $_REQUEST['To'] = $connected_to;
 sms_storeCallData($_REQUEST, $error);
 
+// send a text to those who receive answer alerts
+if (!alertOfAnsweredCall($_REQUEST['From'], $connected_to, $error)) {
+	db_error($error);
+}
+
 // return an empty response
 $response = new Twilio\Twiml();
 echo $response;
 
 db_databaseDisconnect();
+
+/**
+* Send a text notifying contacts of an answered call
+*
+* ...
+* 
+* @param string $from
+*   The phone number of the caller.
+* @param string $to
+*   The phone number of the answerer.
+* @param string &$error
+*   An error if one occurred.
+*   
+* @return bool
+*   True if sent successfully.
+*/
+
+function alertOfAnsweredCall($from, $to, &$error)
+{
+	global $HOTLINE_NAME;
+	
+	// look up who is on duty who receives call answer alerts
+	$receives = array('calls' => false, 'texts' => false, 'answered_alerts' => true);
+	if (!sms_getActiveContacts($contacts, 0 /* no language restriction */, $receives, $error)) {
+		return false;
+	}
+	
+	if (count($contacts) == 0) {
+		// no one on duty, nothing to send
+		return true;
+	}
+	
+	// format the numbers
+	$numbers = array();
+	foreach ($contacts as $contact) {
+		if ($contact['phone'] == $to) {
+			// don't send an alert to the person who just answered
+			//continue;
+		}
+		$numbers[] = $contact['phone'];
+	}
+	
+	// identify the caller
+	if (sms_whoIsCaller($contact_name, $from, $error) && $contact_name) {
+		$from .= " ({$contact_name})";
+	}
+	
+	// identify the answerer
+	if (sms_whoIsCaller($contact_name, $to, $error) && $contact_name) {
+		$to .= " ({$contact_name})";
+	}
+
+	// compose the text
+    $body = "{$HOTLINE_NAME} hotline call from {$from} was answered by {$to}.";
+		
+	// send the texts
+	if (!sms_send($numbers, $body, $error)) {
+		return false;
+	}
+	
+	return true;
+}
 
 ?>

--- a/twin/voicemail-record.php
+++ b/twin/voicemail-record.php
@@ -69,12 +69,9 @@ function alertVolunteersOfVoicemail($from, $url, $duration, &$error)
 {
 	global $HOTLINE_NAME;
 	
-	// compost the text
-    $body = "{$HOTLINE_NAME} hotline has received a {$duration} second message from {$from}. ".
-		"Log in to the website to listen to this voicemail.";
-		
-	// look up who is on duty
-	if (!sms_getActiveContacts($contacts, 0 /* no language restriction */, true /* texting */, $error)) {
+	// look up who is on duty who receives texts
+	$receives = array('calls' => false, 'texts' => true, 'answered_alerts' => false);
+	if (!sms_getActiveContacts($contacts, 0 /* no language restriction */, $receives, $error)) {
 		return false;
 	}
 	
@@ -94,6 +91,10 @@ function alertVolunteersOfVoicemail($from, $url, $duration, &$error)
 		$from .= " ({$contact_name})";
 	}
 
+	// compose the text
+    $body = "{$HOTLINE_NAME} hotline has received a {$duration} second message from {$from}. ".
+		"Log in to the website to listen to this voicemail.";
+		
 	// send the texts
 	if (!sms_send($numbers, $body, $error)) {
 		return false;


### PR DESCRIPTION
I added the option for receiving calls and receiving call answered alerts.  Call answered alerts will allow situation navigators to receive a text when a call is answered, and know who answered it.

I also went ahead and added a modal dialog for easier adding of call time entries.  I probably should have done this in a separate pull request but I was inspired.