### PR TITLE
Broadcast calls to message

### DIFF
--- a/config_sample.php
+++ b/config_sample.php
@@ -47,6 +47,17 @@ $BROADCAST_WELCOME = "Welcome to the ". $HOTLINE_NAME . " alert list. ".
 	"text ON.";
 $BROADCAST_GOODBYE = "You will no longer receive ". $HOTLINE_NAME . " alerts.";
 
+// If set, callers will hear this message in each language and then it will hang up.  The format is an array, 
+// with each key the language code, and the value the text to read in that language.  "es-MX" is Spanish, 
+// "en-US" is English.
+// Example: 'en-US' => "Goodbye"
+$BROADCAST_VOICE_MESSAGES = array(
+
+);
+
+// If set, callers will hear this message and then it will hang up.
+$BROADCAST_VOICE_MESSAGE = '';
+
 // List users authorized to send broadcast texts here.  Leave blank to allow all users.
 $BROADCAST_AUTHORIZED_USERS = array();
 

--- a/config_sample.php
+++ b/config_sample.php
@@ -55,9 +55,6 @@ $BROADCAST_VOICE_MESSAGES = array(
 
 );
 
-// If set, callers will hear this message and then it will hang up.
-$BROADCAST_VOICE_MESSAGE = '';
-
 // List users authorized to send broadcast texts here.  Leave blank to allow all users.
 $BROADCAST_AUTHORIZED_USERS = array();
 

--- a/twin/incoming-voice.php
+++ b/twin/incoming-voice.php
@@ -6,9 +6,10 @@
 * Welcome message, prompts for language, sends to incoming-voice-dial.php
 * when a digit is pressed or after a 15 second timeout.
 * 
-* Calls to the broadcast number will play a recorded message and hangup,
-* if a message is set.  Otherwise, calls will be routed to the hotline.
-* s
+* Calls to the broadcast number will play recorded messages in each
+* language and hangup, if messages are set.  Otherwise, calls will be 
+* routed to the hotline.
+* 
 */
 
 require_once '../config.php';

--- a/twin/incoming-voice.php
+++ b/twin/incoming-voice.php
@@ -6,6 +6,9 @@
 * Welcome message, prompts for language, sends to incoming-voice-dial.php
 * when a digit is pressed or after a 15 second timeout.
 * 
+* Calls to the broadcast number will play a recorded message and hangup,
+* if a message is set.  Otherwise, calls will be routed to the hotline.
+* s
 */
 
 require_once '../config.php';
@@ -16,35 +19,46 @@ db_databaseConnect();
 // store call info
 sms_storeCallData($_REQUEST, $error);
 
+// the call data
+$to = $_REQUEST['To'];
+
 // load the list of languages
 if (!db_db_query("SELECT * FROM languages ORDER BY keypress", $languages, $error)) {
     // error!
 }
 
 $response = new Twilio\Twiml();
+// is this a broadcast text, and is a message set?
+if (($to == $BROADCAST_CALLER_ID) && count($BROADCAST_VOICE_MESSAGES) > 0) {
+	// play broadcast messages in each language and hangup
+	foreach ($BROADCAST_VOICE_MESSAGES as $language_code => $message) {
+		sms_playOrSay($response, $message, $language_code);
+	}	
+} else {
+	// use hotline functionality
+	// wait for a key to be pressed
+	$gather = $response->gather(array(
+		'action' => 'incoming-voice-dial.php',
+		'numDigits' => 1,
+		'timeout' => 15,
+		)
+	);
 
-// wait for a key to be pressed
-$gather = $response->gather(array(
-	'action' => 'incoming-voice-dial.php',
-	'numDigits' => 1,
-	'timeout' => 15,
-	)
-);
+	// say the hotline intro
+	sms_playOrSay($gather, $HOTLINE_INTRO);
 
-// say the hotline intro
-sms_playOrSay($gather, $HOTLINE_INTRO);
+	// and each of the language options
+	foreach ($languages as $language) {
+		sms_playOrSay($gather, $language['prompt'], $language['twilio_code']);
+	}
 
-// and each of the language options
-foreach ($languages as $language) {
-    sms_playOrSay($gather, $language['prompt'], $language['twilio_code']);
+	sms_playOrSay($gather, $HOTLINE_STRAIGHT_TO_VOICEMAIL);
+
+	// and handle a timeout
+	$response->redirect('incoming-voice-dial.php?Digits=TIMEOUT',
+		array('method' => 'GET')
+	);
 }
-
-sms_playOrSay($gather, $HOTLINE_STRAIGHT_TO_VOICEMAIL);
-
-// and handle a timeout
-$response->redirect('incoming-voice-dial.php?Digits=TIMEOUT',
-	array('method' => 'GET')
-);
 
 echo $response;
 


### PR DESCRIPTION
Plays a message in multiple languages for incoming calls to the broadcast number, if set.  Otherwise routes calls to the hotline.

By default, the "config_sample.php" file doesn't include any message.  Here are the two entries I added for testing:

```
'es-MX' => "Este es el número de texto de difusión para el Centro de Trabajadores del Valle de Pioneer. ".
		"Para comunicarse con ellos, llame al 413-570-3060. Adiós.",
'en-US' => "This is the broadcast text number for the Pioneer Valley Workers Center. ".
		"To reach them, call 413-570-3060.  Goodbye."

```