### PR TITLE
Made several improvements to the "call times" section of the "staff"

### DIFF
--- a/hotline_active_calls.php
+++ b/hotline_active_calls.php
@@ -1,0 +1,72 @@
+<?php
+/**
+* @file
+* Active
+*
+* Display currently active calls.
+*
+*/
+
+require_once 'config.php';
+require_once $LIB_BASE . 'lib_sms.php';
+
+include 'header.php';
+
+?>
+		<h2 class="sub-header">Hotline</h2>
+   		  <ul class="nav nav-pills">
+            <li role="presentation" class="active"><a href="hotline_active_calls.php">Active Calls</a></li>
+			<li role="presentation"><a href="hotline_staff.php">Staff</a></li>
+			<li role="presentation"><a href="hotline_blocks.php">Blocks</a></li>
+			<li role="presentation"><a href="hotline_languages.php">Languages</a></li>
+			<li role="presentation"><a href="log.php?ph=<?php echo sms_getFirstHotline($hotline_number, $hotline, $error) ? urlencode($hotline_number) : '' ?>">Log</a></li>
+		  </ul>
+		  <br />
+<?php
+
+// Active calls from and to the hotlines
+$calls = array();
+foreach ($HOTLINES as $hotline_number => $hotline) {
+    sms_getActiveCalls($hotline_number, '', $calls_from, $error);
+    sms_getActiveCalls('', $hotline_number, $calls_to, $error);
+    $calls = array_merge($calls_from, $calls_to, $calls);
+}
+
+if (count($calls)) {
+    ?>
+        <h3 class="sub-header">Active calls</h3>
+		  <div class="table-responsive">
+            <table class="table table-striped">
+              <thead>
+                <tr>
+                  <th>from</th>
+                  <th>to</th>
+                  <th>status</th>
+                  <th>timing</th>
+                </tr>
+              </thead>
+              <tbody>
+<?php
+    foreach ($calls as $call) {
+        $duration = strtotime($call['EndTime']) - strtotime($call['StartTime']); ?>
+                <tr>
+                  <td><?php
+                  echo '<a href="contact.php?ph=' . urlencode($call['From']) . '">' . $call['From'] . '</a>'; ?></td>
+                  <td><?php
+                  echo '<a href="contact.php?ph=' . urlencode($call['To']) . '">' . $call['To'] . '</a>'; ?></td>
+                  <td><?php echo $call['Status']?></td>
+                  <td><?php echo date("m/d/y h:i a", strtotime($call['StartTime'])) .
+                                 ' (' . $duration . ' seconds)' ?></td>
+                </tr>
+<?php
+    } ?>
+              </tbody>
+            </table>
+          </div>
+<?php
+} else {
+        ?>
+        <p>There are currently no active calls.</p>
+<?php
+    }
+?>

--- a/hotline_blocks.php
+++ b/hotline_blocks.php
@@ -4,7 +4,7 @@
 * Blocks
 *
 * Display and edit blocked phone numbers
-* 
+*
 */
 
 require_once 'config.php';
@@ -21,10 +21,10 @@ $id = isset($_REQUEST['id']) ? $_REQUEST['id'] : '';
 
 // add?
 if ($action == 'add') {
-	addBlockedNumber($phone, $error, $success);
-// remove?
-} else if ($action == 'remove') {
-	removeBlockedNumber($id, $error, $success);
+    addBlockedNumber($phone, $error, $success);
+    // remove?
+} elseif ($action == 'remove') {
+    removeBlockedNumber($id, $error, $success);
 }
 
 // load blocks
@@ -33,14 +33,14 @@ db_db_query($sql, $blocks, $error);
 
 // any error message?
 if (!empty($error)) {
-?>
+    ?>
 	      <div class="alert alert-danger" role="alert"><?php echo $error ?></div>
 <?php
 }
 
 // any success message?
 if (!empty($success)) {
-?>
+    ?>
 	      <div class="alert alert-success" role="alert"><?php echo $success ?></div>
 <?php
 }
@@ -48,6 +48,7 @@ if (!empty($success)) {
 ?>
 		<h2 class="sub-header">Hotline</h2>
    		  <ul class="nav nav-pills">
+            <li role="presentation"><a href="hotline_active_calls.php">Active Calls</a></li>
 			<li role="presentation"><a href="hotline_staff.php">Staff</a></li>
 			<li role="presentation" class="active"><a href="hotline_blocks.php">Blocks</a></li>
 			<li role="presentation"><a href="hotline_languages.php">Languages</a></li>
@@ -64,16 +65,15 @@ if (!empty($success)) {
 		   <div class="form-group">
 			<label for="add-phone">Number to block:</label>
 			<input type="text" class="form-control" name="phone" id="add-phone" size="20" />
- 		   </div>		 
+ 		   </div>
 		   <button class="btn btn-success" id="button-text">Add</button>
 		  </form>
         <h3 class="sub-header">Blocks</h3>
         <p>
-<?php 
+<?php
 foreach ($blocks as $block) {
-	echo '<b>' . $block['phone'] . '</b> (blocked ' . date("m/d/y h:i a", strtotime($block['added'])) . ') ';
-?>
-		 <a href="hotline_blocks.php?action=remove&id=<?php echo $block['id'] ?>" 
+    echo '<b>' . $block['phone'] . '</b> (blocked ' . date("m/d/y h:i a", strtotime($block['added'])) . ') '; ?>
+		 <a href="hotline_blocks.php?action=remove&id=<?php echo $block['id'] ?>"
 		   onClick="return confirm('Are you sure you want to remove this block?');">
 		 <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a><br />
 <?php
@@ -88,78 +88,78 @@ include 'footer.php';
 * Add a blocked phone number to the database
 *
 * ...
-* 
+*
 * @param string $phone
 *   The number to block.
 * @param string &$error
 *   Errors if any occurred.
 * @param string &$message
 *   An informational message if appropriate.
-*   
+*
 * @return bool
 *   True if added successfully.
 */
 
 function addBlockedNumber($phone, &$error, &$message)
 {
-	$error = '';
-	$message = '';
-	
-	if (!trim($phone)) {
-		$error = "No number provided.";
-		return false;
-	}
-	
-	// make sure the number is in E164 format
-	if (!sms_normalizePhoneNumber($phone, $error)) {
-		return false;
-	}
+    $error = '';
+    $message = '';
 
-	// is this number in the database already?
-	$sql = "SELECT COUNT(*) FROM blocked_numbers WHERE phone='".addslashes($phone)."'";
-	if (!db_db_getone($sql, $number_exists, $error)) {
-		return false;
-	}
-	if ($number_exists > 0) {
-		$error = "{$number} is already blocked.";
-		return false;
-	}
-		
-	// add the number to the database
-	$sql = "INSERT INTO blocked_numbers SET phone='".addslashes($phone)."'";
-	if (!db_db_command($sql, $error)) {
-		return false;
-	}
-	
-	$message = "Added {$phone} to the block list.";
-	return true;
+    if (!trim($phone)) {
+        $error = "No number provided.";
+        return false;
+    }
+
+    // make sure the number is in E164 format
+    if (!sms_normalizePhoneNumber($phone, $error)) {
+        return false;
+    }
+
+    // is this number in the database already?
+    $sql = "SELECT COUNT(*) FROM blocked_numbers WHERE phone='".addslashes($phone)."'";
+    if (!db_db_getone($sql, $number_exists, $error)) {
+        return false;
+    }
+    if ($number_exists > 0) {
+        $error = "{$number} is already blocked.";
+        return false;
+    }
+
+    // add the number to the database
+    $sql = "INSERT INTO blocked_numbers SET phone='".addslashes($phone)."'";
+    if (!db_db_command($sql, $error)) {
+        return false;
+    }
+
+    $message = "Added {$phone} to the block list.";
+    return true;
 }
 
 /**
 * Remove a phone number block from the database
 *
 * ...
-* 
+*
 * @param int $id
 *   Block id to remove.
 * @param string &$error
 *   Errors if any occurred.
 * @param string &$message
 *   An informational message if appropriate.
-*   
+*
 * @return bool
 *   True unless an error occurred.
 */
 
 function removeBlockedNumber($id, &$error, &$message)
 {
-	$sql = "DELETE FROM blocked_numbers WHERE id='".addslashes($id)."'";
-	if (!db_db_command($sql, $error)) {
-		return false;
-	}
-	
-	$message = "The record was removed.";
-	return true;
+    $sql = "DELETE FROM blocked_numbers WHERE id='".addslashes($id)."'";
+    if (!db_db_command($sql, $error)) {
+        return false;
+    }
+
+    $message = "The record was removed.";
+    return true;
 }
 
 ?>

--- a/hotline_call_times_alpha.php
+++ b/hotline_call_times_alpha.php
@@ -1,0 +1,197 @@
+<?php
+/**
+* @file
+* Call times alphabetically ordered
+*
+* Display and edit call times that are scheduled, ordered alphabetically
+* by staff member name. This file is to be included in a page; it does not
+* work as a standalone page.
+*/
+
+require_once 'hotline_call_times_utils.php';
+
+// Empty call time constant.
+$EMPTY_CALL_TIME = array(
+       'day' => "",
+       'earliest' => -1,
+       'latest' => -1,
+       'language' => "",
+       'receive_texts' => "",
+       'receive_calls' => "",
+       'receive_call_answered_alerts' => "",
+       'types_string' => "",
+       'enabled' => "y"
+   );
+
+// Query the database for the contacts.
+if (!db_db_query("SELECT * FROM contacts ORDER BY contact_name", $contacts, $error)) {
+    echo $error;
+}
+?>
+
+<h3 class="sub-header">Staff</h3>
+<?php createCallTimesDisplayTypeSelector($display_type); ?>
+<div class="table-responsive">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>name</th>
+        <th>phone</th>
+        <th>day</th>
+        <th>from</th>
+        <th>to</th>
+        <th>language</th>
+        <th>types</th>
+        <th>actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <?php
+
+// Iterate over all the contacts, placing each one's call times in
+// the table.
+foreach ($contacts as $contact) {
+    $sql = "SELECT call_times.*,languages.language FROM call_times ".
+            "LEFT JOIN languages ON languages.id = call_times.language_id ".
+            "WHERE contact_id='{$contact['id']}' ".
+            "ORDER BY call_times.day, call_times.earliest, call_times.latest, ".
+            "languages.language, call_times.enabled";
+    if (!db_db_query($sql, $call_times, $error)) {
+        echo $error;
+    } ?>
+      <tr>
+        <td><?php echo $contact['contact_name']?></td>
+        <td><?php echo getContactNumber($contact['phone']); ?></td>
+        <?php
+
+    // Allow removal of staff entry if all call time records are
+    // removed.
+    if (count($call_times) == 0) {
+        ?>
+        <td></td><td></td><td></td><td></td><td></td><td>
+          <a href="hotline_staff.php?display_type=alphabetical&action=removestaff&id=<?php
+                echo $contact['id'] ?>"
+              onClick="return confirm('Are you sure you want to remove this staff entry?');"
+              title="Remove this staff entry">
+            <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
+        <?php
+    } else {
+
+        // Display each call time record that is not an exact
+        // repeat of the previous one, crossed out if disabled.
+        $first = true;
+        $last_call_time = $EMPTY_CALL_TIME;
+        foreach ($call_times as $call_time) {
+
+            // If this is not the first call time for this contact,
+            // ensure that it should be shown, and if so, pad it
+            // with empty table cells since the leftmost ones do
+            // not need repeating.
+            if ($first) {
+                $first = false;
+            } else {
+
+                // If the previous call time entry and this one
+                // do not have the same enabled state, ensure
+                // that this one is fully displayed, with no
+                // empty cells for its days, times, etc. If the
+                // two have the same enabled state, see if this
+                // one is simply a repeat of the previous one,
+                // and if so, skip it.
+                if ($last_call_time['enabled'] != $call_time['enabled']) {
+                    $last_call_time = $EMPTY_CALL_TIME;
+                } elseif (areArrayValuesEqual($call_time, $last_call_time, array(
+                    'day', 'earliest', 'latest', 'receive_texts', 'receive_calls',
+                    'receive_call_answered_alerts', 'language'))) {
+                    continue;
+                }
+
+                // Add the start of a table row, and a couple of
+                // empty cells to pad it to the left, since the
+                // contact info cells do not need to be repeated.
+                echo "<tr><td></td><td></td>";
+            }
+
+            // Get cell decorations for the contents of any table
+            // cell for this call time entry.
+            $cell_decorations = getCellDecorations(
+                $call_time,
+                'enabled',
+                'receive_calls',
+                'receive_texts'
+            );
+
+            // Days and times.
+            $force_display = createCallTimeTableCell(
+                $call_time,
+                $last_call_time,
+                'day',
+                $cell_decorations,
+                false
+            );
+            $force_display = createCallTimeRangeTableCells(
+                $call_time,
+                $last_call_time,
+                'earliest',
+                'latest',
+                $cell_decorations,
+                $force_display
+            );
+
+            // Language.
+            $force_display = createCallTimeTableCell(
+                $call_time,
+                $last_call_time,
+                'language',
+                $cell_decorations,
+                $force_display
+            );
+
+            // Types of calls/messages that can be received.
+            createCallTimeTypesTableCell($call_time, $last_call_time, array(
+                'receive_texts' => "texts",
+                'receive_calls' => "calls",
+                'receive_call_answered_alerts' => "answer alerts"
+            ), $cell_decorations, $force_display);
+
+            // Remember this call time for the next one, so that values
+            // that have not changed can be output as blank table cells.
+            $last_call_time = $call_time; ?>
+        <td>
+          <a href="hotline_staff.php?display_type=alphabetical&action=editcalltimemodal&id=<?php
+                echo $call_time['id'] ?>"
+                title="Edit this call time">
+            <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></a>
+          <a href="hotline_staff.php?display_type=alphabetical&action=removecalltime&id=<?php
+                echo $call_time['id'] ?>"
+                onClick="return confirm('Are you sure you want to remove this call time?');"
+                title="Remove this call time">
+            <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
+        </td>
+      </tr>
+      <?php
+
+        // Close the foreach loop; iteration over the call times is
+        // done.
+        } ?>
+      <tr>
+        <td></td><td></td><td></td><td></td><td></td><td></td><td></td><td>
+          <?php
+
+    // Close the else block; call times have all been processed for
+    // this contact.
+    } ?>
+          <a href="hotline_staff.php?display_type=alphabetical&action=addcalltimemodal&id=<?php
+                echo $contact['id'] ?>"
+              title="Add a call time">
+            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span></a>
+        </td>
+      </tr>
+      <?php
+
+// Close the foreach loop; iteration over all the contacts is done.
+}
+      ?>
+    </tbody>
+  </table>
+</div>

--- a/hotline_call_times_alpha.php
+++ b/hotline_call_times_alpha.php
@@ -162,6 +162,10 @@ foreach ($contacts as $contact) {
             // that have not changed can be output as blank table cells.
             $last_call_time = $call_time; ?>
         <td>
+          <a href="hotline_staff.php?display_type=alphabetical&action=addcalltimemodal&id=<?php
+                echo $contact['id'] ?>"
+                title="Add a call time for this staff member">
+            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span></a>
           <a href="hotline_staff.php?display_type=alphabetical&action=editcalltimemodal&id=<?php
                 echo $call_time['id'] ?>"
                 title="Edit this call time">
@@ -175,21 +179,12 @@ foreach ($contacts as $contact) {
       </tr>
       <?php
 
-        // Close the foreach loop; iteration over the call times is
-        // done.
-        } ?>
-      <tr>
-        <td colspan="7"></td><td>
-          <a href="hotline_staff.php?display_type=alphabetical&action=addcalltimemodal&id=<?php
-                echo $contact['id'] ?>"
-              title="Add a call time">
-            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span></a>
-        </td>
-      </tr>
-      <?php
+            // Close the foreach loop; iteration over the call times is
+            // done.
+        }
 
-    // Close the else block; call times have all been processed for
-    // this contact.
+        // Close the else block; call times have all been processed for
+        // this contact.
     }
 
     // Close the foreach loop; iteration over all the contacts is done.

--- a/hotline_call_times_alpha.php
+++ b/hotline_call_times_alpha.php
@@ -68,7 +68,11 @@ foreach ($contacts as $contact) {
     // removed.
     if (count($call_times) == 0) {
         ?>
-        <td></td><td></td><td></td><td></td><td></td><td>
+        <td colspan="5"></td><td>
+          <a href="hotline_staff.php?display_type=alphabetical&action=addcalltimemodal&id=<?php
+                echo $contact['id'] ?>"
+                title="Add a call time">
+            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span></a>
           <a href="hotline_staff.php?display_type=alphabetical&action=removestaff&id=<?php
                 echo $contact['id'] ?>"
               onClick="return confirm('Are you sure you want to remove this staff entry?');"
@@ -109,7 +113,7 @@ foreach ($contacts as $contact) {
                 // Add the start of a table row, and a couple of
                 // empty cells to pad it to the left, since the
                 // contact info cells do not need to be repeated.
-                echo "<tr><td></td><td></td>";
+                echo '<tr><td colspan="2"></td>';
             }
 
             // Get cell decorations for the contents of any table
@@ -175,12 +179,7 @@ foreach ($contacts as $contact) {
         // done.
         } ?>
       <tr>
-        <td></td><td></td><td></td><td></td><td></td><td></td><td></td><td>
-          <?php
-
-    // Close the else block; call times have all been processed for
-    // this contact.
-    } ?>
+        <td colspan="7"></td><td>
           <a href="hotline_staff.php?display_type=alphabetical&action=addcalltimemodal&id=<?php
                 echo $contact['id'] ?>"
               title="Add a call time">
@@ -189,7 +188,11 @@ foreach ($contacts as $contact) {
       </tr>
       <?php
 
-// Close the foreach loop; iteration over all the contacts is done.
+    // Close the else block; call times have all been processed for
+    // this contact.
+    }
+
+    // Close the foreach loop; iteration over all the contacts is done.
 }
       ?>
     </tbody>

--- a/hotline_call_times_chrono.php
+++ b/hotline_call_times_chrono.php
@@ -1,0 +1,473 @@
+<?php
+/**
+* @file
+* Call times chronologically ordered
+*
+* Display and edit call times that are scheduled, ordered chronologically.
+* This file is to be included in a page; it does not work as a standalone
+* page.
+*/
+
+require_once 'hotline_call_times_utils.php';
+
+// Empty call time constant.
+$EMPTY_CALL_TIME = array(
+        'original_day' => "",
+        'original_day_ordinal' => -1,
+        'day_of_week' => "",
+        'day_ordinal' => -1,
+        'earliest_time' => -1,
+        'latest_time' => -1,
+        'takes_calls' => "",
+        'takes_texts' => "",
+        'takes_alerts' => "",
+        'types_string' => "",
+        'enabled_choice' => "y",
+        'language_choice' => "",
+        'staff_name' => "",
+        'phone' => ""
+   );
+
+// Query mode dicates how the query is performed. It has two possible
+// values: "pureSql" or "hybrid". The former uses a large multipart,
+// UNIONed SELECT statement to perform the query. The latter uses four
+// separate SELECT statements to query the single- and multi-day rows,
+// and then merges them together using PHP.
+$QUERY_MODE = "hybrid";
+
+// Test mode, if true, indicates whether testing should be performed
+// instead of displaying query results.
+$TEST_MODE = false;
+
+//  If testing, run each query many times and output the time taken.
+// Otherwise, run the appropriate query and display the results.
+if ($TEST_MODE) {
+
+    // Time the hybrid approach.
+    $startTimeMicros = microtime(true);
+    for ($j = 0; $j < 1000; $j++) {
+        $call_times = getResultsUsingHybridQuery();
+    }
+    $call_times_count = count($call_times);
+    $timeHybridApproach = round((microtime(true) - $startTimeMicros) * 1000);
+
+    // Time the pure SQL approach.
+    $startTimeMicros = microtime(true);
+    for ($j = 0; $j < 1000; $j++) {
+        $call_times = getResultsUsingPureSqlQuery();
+    }
+    $timePureSqlApproach = round((microtime(true) - $startTimeMicros) * 1000);
+
+    // Show the test results.
+    echo '<div class="alert alert-success" role="alert">'.
+        'Time taken for pure SQL approach was '. $timePureSqlApproach.
+        ' milliseconds, yielding '. $call_times_count. ' records.<br>'.
+        'Time taken for hybrid SQL/PHP approach was '. $timeHybridApproach.
+        ' milliseconds, yielding '. count($call_times). ' records.'.
+        '</div>';
+} else {
+
+    // Get the call times.
+    $call_times = ($QUERY_MODE == "hybrid" ? getResultsUsingHybridQuery() :
+            getResultsUsingPureSqlQuery());
+
+    // Show the header.?>
+
+    <h3 class="sub-header">Call Times</h3>
+
+    <?php
+
+    // Show the display type selector.
+    createCallTimesDisplayTypeSelector($display_type);
+
+    // Provide a message if there are no call times; otherwise, show a table
+    // with the call times.
+    if (count($call_times) == 0) {
+        ?>
+        <div><br>There are no call times on record.<br><br></div>
+        <?php
+    } else {
+
+        // Start the table.?>
+        <div class="table-responsive">
+          <table class="table table-striped">
+            <thead>
+              <tr>
+                <th>day</th>
+                <th>from</th>
+                <th>to</th>
+                <th>name</th>
+                <th>phone</th>
+                <th>language</th>
+                <th>types</th>
+                <th>actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <?php
+
+        // Iterate through the call times, displaying each in turn.
+        $last_call_time = $EMPTY_CALL_TIME;
+        foreach ($call_times as $call_time) {
+
+            // If the previous call time entry and this one do not
+            // have the same enabled state, ensure that this one is
+            // fully displayed, with no empty cells for its days,
+            // times, etc. If the two have the same enabled state,
+            // see if this one is simply a repeat of the previous
+            // one, and if so, skip it.
+            if ($last_call_time['enabled_choice'] != $call_time['enabled_choice']) {
+                $last_day = $last_call_time['day_of_week'];
+                $last_call_time = $EMPTY_CALL_TIME;
+                if ($call_time['day_of_week'] == $last_day) {
+                    $last_call_time['day_of_week'] = $last_day;
+                }
+            } elseif (areArrayValuesEqual($call_time, $last_call_time, array(
+                'day_of_week', 'earliest_time', 'latest_time', 'takes_calls',
+                'takes_texts', 'takes_alerts', 'language_choice', 'staff_name'))) {
+                continue;
+            }
+
+            // Add the start of a table row.
+            echo "<tr>";
+
+            // Get cell decorations for the contents of any table
+            // cell for this call time entry.
+            $cell_decorations = getCellDecorations(
+                $call_time,
+                'enabled_choice',
+                'takes_calls',
+                'takes_texts'
+            );
+
+            // Day and times.
+            $force_display = createCallTimeTableCell(
+                $call_time,
+                $last_call_time,
+                'day_of_week',
+                $cell_decorations,
+                false
+            );
+            $force_display = createCallTimeRangeTableCells(
+                $call_time,
+                $last_call_time,
+                'earliest_time',
+                'latest_time',
+                $cell_decorations,
+                $force_display
+            );
+
+            // Name, number, and language.
+            $force_display = createCallTimeTableCell(
+                $call_time,
+                $last_call_time,
+                'staff_name',
+                $cell_decorations,
+                $force_display
+            );
+            $force_display = createCallTimeTablePhoneCell(
+                $call_time,
+                $last_call_time,
+                'phone',
+                $cell_decorations,
+                $force_display
+            );
+            $force_display = createCallTimeTableCell(
+                $call_time,
+                $last_call_time,
+                'language_choice',
+                $cell_decorations,
+                $force_display
+            );
+
+            // Types of calls/messages that can be received.
+            createCallTimeTypesTableCell($call_time, $last_call_time, array(
+                'takes_texts' => "texts",
+                'takes_calls' => "calls",
+                'takes_alerts' => "answer alerts"
+            ), $cell_decorations, $force_display);
+
+            // Remember this call time for the next one, so that values
+            // that have not changed can be output as blank table cells.
+            $last_call_time = $call_time;
+
+            // Create the removal confirmation message.
+            $confirmation_message = "Are you sure you want to remove this call time?";
+            if ($call_time['original_day'] == "all") {
+                $confirmation_message .=
+                    " It is scheduled for every day, so deleting it will ".
+                    "remove it from all seven days of the week, not just ".
+                    "this day.";
+            } elseif ($call_time['original_day'] == "weekends") {
+                $confirmation_message .=
+                    " It is scheduled for both weekend days, so deleting it ".
+                    "will remove it from both such days, not just this day.";
+            } elseif ($call_time['original_day'] == "weekdays") {
+                $confirmation_message .=
+                    " It is scheduled for all weekdays, so deleting it will ".
+                    "remove it from all such days, not just this day.";
+            }
+
+            // Action buttons.?>
+            <td>
+              <a href="hotline_staff.php?display_type=chronological&action=editcalltimemodal&id=<?php
+                    echo $call_time['id'] ?>"
+                    title="Edit this call time">
+                  <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></a>
+              <a href="hotline_staff.php?display_type=chronological&action=removecalltime&id=<?php
+                    echo $call_time['id'] ?>"
+                  onClick="return confirm('<?php echo $confirmation_message; ?>');"
+                  title="Remove this call time">
+               <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
+            </td>
+            <?php
+            echo "</tr>";
+        }
+
+        // Finish the table.?>
+            </tbody>
+          </table>
+        </div>
+        <?php
+    }
+}
+
+/**
+* Get the call times using a hybrid query.
+*
+* @return array List of call times ordered chronologically.
+*/
+function getResultsUsingHybridQuery()
+{
+
+    // Get the multi-day call times.
+    $multiDayResults = array();
+    foreach (array("all", "weekends", "weekdays") as $dayType) {
+
+        // Query the database for the call times with this particular
+        // multi-day specifier.
+        $query =
+            "SELECT DISTINCT ".
+                "call_times.id, ".
+                "call_times.day AS original_day, ".
+                "call_times.day + 0 AS original_day_ordinal, ".
+                "call_times.earliest AS earliest_time, ".
+                "call_times.latest AS latest_time, ".
+                "call_times.receive_calls AS takes_calls, ".
+                "call_times.receive_texts AS takes_texts, ".
+                "call_times.receive_call_answered_alerts AS takes_alerts, ".
+                "call_times.enabled AS enabled_choice, ".
+                "languages.language AS language_choice, ".
+                "contacts.contact_name AS staff_name, ".
+                "contacts.phone ".
+            "FROM ".
+                "call_times ".
+            "LEFT JOIN ".
+                "languages ON languages.id = call_times.language_id ".
+            "LEFT JOIN ".
+                "contacts ON contacts.id = call_times.contact_id ".
+            "WHERE ".
+                "day = '".$dayType."' ";
+        if (!db_db_query($query, $multiDayResults[$dayType], $error)) {
+            echo $error;
+        }
+    }
+
+    // Query the database for the call times with single-day specifiers.
+    $query =
+        "SELECT DISTINCT ".
+            "call_times.id, ".
+            "call_times.day AS original_day, ".
+            "call_times.day + 0 AS original_day_ordinal, ".
+            "call_times.day AS day_of_week, ".
+            "call_times.day - 4 AS day_ordinal, ".
+            "call_times.earliest AS earliest_time, ".
+            "call_times.latest AS latest_time, ".
+            "call_times.receive_calls AS takes_calls, ".
+            "call_times.receive_texts AS takes_texts, ".
+            "call_times.receive_call_answered_alerts AS takes_alerts, ".
+            "call_times.enabled AS enabled_choice, ".
+            "languages.language AS language_choice, ".
+            "contacts.contact_name AS staff_name, ".
+            "contacts.phone ".
+        "FROM ".
+            "call_times ".
+        "LEFT JOIN ".
+            "languages ON languages.id = call_times.language_id ".
+        "LEFT JOIN ".
+            "contacts ON contacts.id = call_times.contact_id ".
+        "WHERE ".
+            "day NOT IN ('all','weekdays', 'weekends') ".
+        "ORDER BY ".
+            "day_ordinal, ".
+            "earliest_time, ".
+            "latest_time, ".
+            "staff_name, ".
+            "takes_calls, ".
+            "takes_texts, ".
+            "takes_alerts, ".
+            "language_choice";
+    if (!db_db_query($query, $call_times, $error)) {
+        echo $error;
+    }
+
+    // Iterate through the multi-day results, adding each in turn
+    // to the single-day results list once for every day it
+    // represents. Thus, an 'all' result is added seven times, once
+    // for each day of the week; a 'weekends' result is added two
+    // times, one per weekend day; and so on.
+    foreach (array(
+        "all" => array("Sun" => 0, "Mon" => 1, "Tue" => 2, "Wed" => 3,
+                        "Thu" => 4, "Fri" => 5, "Sat" => 6),
+        "weekends" => array("Sun" => 0, "Sat" => 6),
+        "weekdays" => array("Mon" => 1, "Tue" => 2, "Wed" => 3,
+                        "Thu" => 4, "Fri" => 5)
+    ) as $grouping => $days) {
+        foreach ($multiDayResults[$grouping] as $multiDayResult) {
+            foreach ($days as $day => $ordinal) {
+
+                // Copy he multi-day result, then insert into it
+                // valuesfor the 'day_of_week' and 'day_ordinal'
+                // indices. Then add it to the list of single-day
+                // results.
+                $result = $multiDayResult;
+                $result["day_of_week"] = $day;
+                $result["day_ordinal"] = $ordinal;
+                $call_times[] = $result;
+            }
+        }
+    }
+
+    // Sort the results to complete the merge.
+    usort($call_times, "compareCallTimesChronologically");
+
+    return $call_times;
+}
+
+/**
+* Get the call times using a pure SQL query.
+*
+* @return array List of call times ordered chronologically.
+*/
+function getResultsUsingPureSqlQuery()
+{
+
+    // Build the query string.
+    $dayOrdinal = 0;
+    $query = "";
+    foreach (array(
+        "Sun" => "weekends",
+        "Mon" => "weekdays",
+        "Tue" => "weekdays",
+        "Wed" => "weekdays",
+        "Thu" => "weekdays",
+        "Fri" => "weekdays",
+        "Sat" => "weekends"
+    ) as $day => $grouping) {
+        if ($dayOrdinal > 0) {
+            $query = $query." UNION ";
+        }
+        $query .=
+            "(SELECT DISTINCT ".
+                "call_times.id, ".
+                "call_times.day AS original_day, ".
+                "call_times.day + 0 AS original_day_ordinal, ".
+                "'". $day. "' AS day_of_week, ".
+                $dayOrdinal. " AS day_ordinal, ".
+                "call_times.earliest AS earliest_time, ".
+                "call_times.latest AS latest_time, ".
+                "call_times.receive_calls AS takes_calls, ".
+                "call_times.receive_texts AS takes_texts, ".
+                "call_times.receive_call_answered_alerts AS takes_alerts, ".
+                "call_times.enabled AS enabled_choice, ".
+                "languages.language AS language_choice, ".
+                "contacts.contact_name AS staff_name, ".
+                "contacts.phone ".
+            "FROM ".
+                "call_times ".
+            "LEFT JOIN ".
+                "languages ON languages.id = call_times.language_id ".
+            "LEFT JOIN ".
+                "contacts ON contacts.id = call_times.contact_id ".
+            "WHERE ".
+                "day IN ('all', '". $grouping. "', '". $day. "')".
+            ")";
+        $dayOrdinal++;
+    }
+    $query .=
+        " ORDER BY ".
+            "day_ordinal, ".
+            "earliest_time, ".
+            "latest_time, ".
+            "staff_name, ".
+            "takes_calls, ".
+            "takes_texts, ".
+            "takes_alerts, ".
+            "language_choice, ".
+            "enabled_choice, ".
+            "original_day_ordinal";
+
+    // Execute the query.
+    if (!db_db_query($query, $call_times, $error)) {
+        echo "$error";
+    }
+
+    return $call_times;
+}
+
+/**
+* Compare the two specified call times chronologically.
+*
+* @param array &$call_time1
+*   First call time to be compared.
+* @param array &$call_time2
+*   Second call time to be compared.
+* @return int Number that is less than, equal to, or greater than 0
+*   if the first call time is considered to be respectively less than,
+*   equal to, or greater than the second.
+*/
+function compareCallTimesChronologically(&$call_time1, &$call_time2)
+{
+
+    // Compare the day of the week and the start and end times first.
+    foreach (array("day_ordinal", "earliest_time", "latest_time") as $index) {
+        if ($call_time1[$index] != $call_time2[$index]) {
+            return $call_time1[$index] - $call_time2[$index];
+        }
+    }
+
+    // Next, compare the staff member's name.
+    if (($value = strcmp(
+        $call_time1["staff_name"],
+            $call_time2["staff_name"]
+    )) != 0) {
+        return $value;
+    }
+
+    // Then compare the flags indicating what types of messages the
+    // staff member takes.
+    foreach (array("takes_calls", "takes_texts", "takes_alerts") as $index) {
+        if ($call_time1[$index] != $call_time2[$index]) {
+            return ($call_time1[$index] == "y" ? -1 : 1);
+        }
+    }
+
+    // Next, compare the language used by the staff member.
+    if (($value = strcmp(
+        $call_time1["language_choice"],
+            $call_time2["language_choice"]
+    )) != 0) {
+        return $value;
+    }
+
+    // Then compare the enabled flag.
+    if ($call_time1["enabled_choice"] != $call_time2["enabled_choice"]) {
+        return ($call_time1["enabled_choice"] == "y" ? -1 : 1);
+    }
+
+    // Finally, compare the original day ordinal, so that 'all' comes
+    // before 'weekends', and so on.
+    return $call_time1["original_day_ordinal"] - $call_time2["original_day_ordinal"];
+}
+
+?>

--- a/hotline_call_times_chrono.php
+++ b/hotline_call_times_chrono.php
@@ -210,6 +210,10 @@ if ($TEST_MODE) {
 
             // Action buttons.?>
             <td>
+              <a href="hotline_staff.php?display_type=chronological&action=addcalltimemodal&id=<?php
+                    echo $call_time['staff_id'] ?>"
+                    title="Add a call time for this staff member">
+                  <span class="glyphicon glyphicon-plus" aria-hidden="true"></span></a>
               <a href="hotline_staff.php?display_type=chronological&action=editcalltimemodal&id=<?php
                     echo $call_time['id'] ?>"
                     title="Edit this call time">
@@ -259,6 +263,7 @@ function getResultsUsingHybridQuery()
                 "call_times.enabled AS enabled_choice, ".
                 "languages.language AS language_choice, ".
                 "contacts.contact_name AS staff_name, ".
+                "contacts.id AS staff_id, ".
                 "contacts.phone ".
             "FROM ".
                 "call_times ".
@@ -289,6 +294,7 @@ function getResultsUsingHybridQuery()
             "call_times.enabled AS enabled_choice, ".
             "languages.language AS language_choice, ".
             "contacts.contact_name AS staff_name, ".
+            "contacts.id AS staff_id, ".
             "contacts.phone ".
         "FROM ".
             "call_times ".
@@ -382,6 +388,7 @@ function getResultsUsingPureSqlQuery()
                 "call_times.enabled AS enabled_choice, ".
                 "languages.language AS language_choice, ".
                 "contacts.contact_name AS staff_name, ".
+                "contacts.id AS staff_id, ".
                 "contacts.phone ".
             "FROM ".
                 "call_times ".

--- a/hotline_call_times_modal.php
+++ b/hotline_call_times_modal.php
@@ -1,0 +1,189 @@
+<?php
+/**
+* @file
+* Call times modal dialog, for adding or editing call times.
+*
+* This file is to be included in a page; it does not work as a standalone
+* page.
+*/
+
+require_once 'hotline_call_times_utils.php';
+
+// Set up the initial values to be displayed by the dialog differently
+// depending upon whether a new call time is being added, or an existing
+// one is being edited.
+if ($modal_action == "Add") {
+
+    // Get the name of the contact.
+    $sql = "SELECT contact_name FROM contacts WHERE id='".addslashes($id)."'";
+    db_db_getone($sql, $contact_name, $error);
+
+    // Initialize a new call time array.
+    $call_time = array(
+        'contact_id' => $id,
+        'day' => "all",
+        'earliest' => "12:00 am",
+        'latest' => "11:59 pm",
+        'language_id' => null,
+        'receive_texts' => "y",
+        'receive_calls' => "y",
+        'receive_call_answered_alerts' => "n"
+    );
+} else {
+
+    // Get the call time array.
+    $sql = "SELECT * FROM call_times WHERE id='".addslashes($id)."'";
+    db_db_getrow($sql, $call_time, $error);
+    $call_time['earliest'] = getDisplayableTime($call_time['earliest']);
+    $call_time['latest'] = getDisplayableTime($call_time['latest']);
+
+    // Get the name of the contact.
+    $sql = "SELECT contact_name FROM contacts WHERE id='".
+            addslashes($call_time['contact_id']). "'";
+    db_db_getone($sql, $contact_name, $error);
+}
+
+// Create the modal dialog.
+?>
+
+<div class="modal show" tabindex="-1" role="dialog">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <form id="modal-calltime" action="hotline_staff.php" method="POST">
+       <input type="hidden" name="action" value="<?php
+            echo strtolower($modal_action) ?>calltime">
+       <input type="hidden" name="display_type" value="<?php echo $display_type ?>">
+       <?php
+
+if ($modal_action == "Edit") {
+    ?>
+
+       <input type="hidden" name="call_time[id]"
+            value="<?php echo $call_time['id'] ?>">
+
+       <?php
+}
+
+       ?>
+       <input type="hidden" name="call_time[contact_id]"
+            value="<?php echo $call_time['contact_id'] ?>">
+        <div class="modal-header">
+          <a class="btn close"
+                href="hotline_staff.php?display_type=<?php echo $display_type ?>"
+                role="button" aria-label="Close"><span aria-hidden="true">&times;</span></a>
+          <h4 class="modal-title">
+            <strong>
+            <?php echo $modal_action ?> call time for <?php echo $contact_name ?>
+            </strong>
+          </h4>
+        </div>
+        <div class="modal-body">
+          <div class="form-group">
+            <label for="calltime_day">Days</label>
+            <select class="form-control" id="calltime_day" name="call_time[day]">
+              <?php
+
+foreach (array('all', 'weekdays', 'weekends', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat') as $day) {
+    echo "<option". ($day == $call_time['day'] ? " selected" : ""). ">". $day. "</option>";
+}
+              ?>
+            </select>
+          </div>
+          <div class="form-group">
+            <label for="calltime_earliest">Earliest time</label>
+            <input type="text" class="form-control" id="calltime_earliest"
+                    name="call_time[earliest]"
+                    value="<?php echo $call_time['earliest'] ?>">
+          </div>
+          <div class="form-group">
+            <label for="calltime_latest">Latest time</label>
+            <input type="text" class="form-control" id="calltime_latest"
+                    name="call_time[latest]"
+                    value="<?php echo $call_time['latest'] ?>">
+          </div>
+          <div class="form-group">
+            <?php
+
+// Create an option for each language if adding, or just show the language
+// selected if editing. This is because the language cannot be editable,
+// since only one of the entries created originally is being edited, and
+// the original addition of the call time may have created multiple entries,
+// one per language.
+//
+// TODO: If the call_times table is changed at some point to associate
+// multiple languages with a single entry, get rid of the code that makes
+// language read-only here; instead, allow all the checkboxes as with a
+// new call time entry.
+if ($modal_action == "Edit") {
+    ?>
+            <input type="hidden" name="call_time[language_id]"
+                value="<?php echo $call_time['language_id'] ?>">
+            <label>Language: </label>
+            <?php
+
+    // Look up the language.
+    $sql = "SELECT language FROM languages WHERE id = '".$call_time["language_id"]."'";
+    db_db_getone($sql, $language, $error);
+    echo " ". $language;
+} else {
+
+            // Output the languages label.?>
+            <label>Languages: </label>
+            <?php
+
+    // Look up the language options.
+    $sql = "SELECT id,language FROM languages ORDER BY language";
+    db_db_query($sql, $languages, $error);
+
+    foreach ($languages as $language) {
+
+            // Output the language checkboxes.?>
+            <label class="checkbox-inline">
+              <input type="checkbox" id="language_<?php echo $language['id'] ?>"
+                    name="call_time_languages[<?php echo $language['id'] ?>]"
+                    <?php
+
+if (($call_time['language_id'] == null) || ($call_time['language_id'] == $language['id'])) {
+    echo " checked";
+} ?>>
+                <?php echo $language['language'] ?>
+            </label>
+<?php
+
+    // End of the foreach loop creating language options.
+    }
+}?>
+          </div>
+          <div class="form-group">
+            <label for="calltime_texts">Receive: </label>
+            <label class="checkbox-inline">
+              <input type="checkbox" id="calltime_texts" name="call_time[receive_texts]"
+                    <?php
+                        echo($call_time['receive_texts'] == "y" ? " checked" : "")
+                    ?>> texts
+            </label>
+            <label class="checkbox-inline">
+              <input type="checkbox" id="calltime_calls" name="call_time[receive_calls]"
+                    <?php
+                        echo($call_time['receive_calls'] == "y" ? " checked" : "")
+                    ?>> calls
+            </label>
+            <label class="checkbox-inline">
+              <input type="checkbox" id="calltime_answered_alerts"
+                    name="call_time[receive_call_answered_alerts]"
+                    <?php
+                        echo($call_time['receive_call_answered_alerts'] == "y" ? " checked" : "")
+                    ?>> call answered alerts
+            </label>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <a class="btn btn-default"
+                href="hotline_staff.php?display_type=<?php echo $display_type ?>"
+                role="button">Close</a>
+          <button type="submit" class="btn btn-primary">Add</button>
+        </div>
+      </form>
+    </div><!-- /.modal-content -->
+  </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->

--- a/hotline_call_times_modal.php
+++ b/hotline_call_times_modal.php
@@ -181,7 +181,7 @@ if (($call_time['language_id'] == null) || ($call_time['language_id'] == $langua
           <a class="btn btn-default"
                 href="hotline_staff.php?display_type=<?php echo $display_type ?>"
                 role="button">Close</a>
-          <button type="submit" class="btn btn-primary">Add</button>
+          <button type="submit" class="btn btn-primary"><?php echo $modal_action ?></button>
         </div>
       </form>
     </div><!-- /.modal-content -->

--- a/hotline_call_times_utils.php
+++ b/hotline_call_times_utils.php
@@ -248,7 +248,7 @@ function createCallTimeRangeTableCells(
         }
         return true;
     } else {
-        echo "<td></td><td></td>";
+        echo '<td colspan="2"></td>';
         return false;
     }
 }
@@ -375,9 +375,12 @@ function addCallTime($call_time, $call_time_languages, &$error, &$message)
 
     // Ensure at least one checkbox is selected (for texts, calls, or
     // answered alerts.
-    $texts = (isset($call_time['texts']) && ($call_time['texts'] == 'on'));
-    $calls = (isset($call_time['calls']) && ($call_time['calls'] == 'on'));
-    $alerts = (isset($call_time['answered_alerts']) && ($call_time['answered_alerts'] == 'on'));
+    $texts = (isset($call_time['receive_texts']) &&
+            ($call_time['receive_texts'] == 'on'));
+    $calls = (isset($call_time['receive_calls']) &&
+            ($call_time['receive_calls'] == 'on'));
+    $alerts = (isset($call_time['receive_call_answered_alerts']) &&
+            ($call_time['receive_call_answered_alerts'] == 'on'));
     if (!$texts && !$calls && !$alerts) {
         $error = "The call time record could not be added because no ".
                 "'received type' checkbox (texts, calls, or call ".

--- a/hotline_call_times_utils.php
+++ b/hotline_call_times_utils.php
@@ -1,0 +1,510 @@
+<?php
+/**
+* @file
+* Call times utilities.
+*
+* Utility functions for call times display.
+*/
+
+/**
+* Determine whether or not the values in the two specified arrays found
+* under the specified indices are equal.
+*
+* @param array &$array1
+*   First array to be compared.
+* @param array &$array2
+*   Second array to be compared.
+* @param array $indices
+*   Indices for which to compare values in the two arrays.
+* @return bool
+*   True if the two arrays are equal at the indices, false otherwise.
+*/
+function areArrayValuesEqual(&$array1, &$array2, $indices)
+{
+    foreach ($indices as $index) {
+        if ($array1[$index] != $array2[$index]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+* Create the call times display type selector.
+*
+* @param string $display_type
+*   Type of display currently being shown; either 'chronological' or
+*   'alphabetical'.
+*/
+function createCallTimesDisplayTypeSelector($display_type)
+{
+    ?>
+    <form action="hotline_staff.php" method="GET" class="form-inline">
+      <div class="form-group">
+        <label for="display_type">Sort order:</label>
+        <select class="form-control" name="display_type" onChange="this.form.submit()">
+          <option value="chronological"
+            <?php
+
+    if ($display_type == "chronological") {
+        echo "selected";
+    } ?>>by day</option>
+          <option value="alphabetical"
+            <?php
+
+    if ($display_type == "alphabetical") {
+        echo "selected";
+    } ?>>by name</option>
+        </select>
+      </div>
+    </form>
+    <?php
+}
+
+/**
+* Given the specified call time, get the cell decorations for all its
+* table cells. The cell decorations are an array of two elements, the
+* first holding a string to be prepended to any cell's contents, the
+* second holding a string to be appended to any cell's contents.
+*
+* @param array &$call_time
+*   Call time information.
+* @param string $enabled_index
+*   Index into $call_time at which to find the is-enabled value.
+* @param string $receive_calls_index
+*   Index into $call_time at which to find the can-receive-calls value.
+* @param string $receive_texts_index
+*   Index into $call_time at which to find the can-receive-texts value.
+* @return array
+*   Array of two strings, one the cell prefix, the other the suffix.
+*/
+function getCellDecorations(
+    &$call_time,
+    $enabled_index,
+    $receive_calls_index,
+    $receive_texts_index
+) {
+    if ($call_time[$enabled_index] == 'n') {
+        return array(
+            '<span style="text-decoration: line-through; color: gray;">',
+            '</span>'
+        );
+    } elseif (($call_time[$receive_calls_index] == 'n') &&
+            ($call_time[$receive_texts_index] == 'n')) {
+        return array('<span style="color: darkred;">', '</span>');
+    } else {
+        return array('', '');
+    }
+}
+
+/**
+* Get a link to the specified phone number.
+*
+* @param string $phone
+*   Phone number.
+* @return string Link to the phone number.
+*/
+function getContactNumber($phone)
+{
+    return '<a href="contact.php?ph='. urlencode($phone). '">'. $phone. '</a>';
+}
+
+/**
+* Get displayable time from the specified time string fetched from a
+* TIME-type column in a database table.
+*
+* @param string time
+*   Time string.
+* @return string
+*   Time string suitable for display.
+*/
+function getDisplayableTime($time)
+{
+    return date("h:i a", strtotime($time));
+}
+
+/**
+* Create a call time table cell, filling it with the value found at the
+* specified index of the specified call time array.
+*
+* @param array &$call_time
+*   Information about the call time from which to extract the relevant
+*   value.
+* @param array &$last_call_time
+*   Information about the previous call time; this is used to determine
+*   whether or not the value has changed from the last one, and if it
+*   has not, to create an empty table cell.
+* @param string $index
+*   Index into $call_time at which to find the relevant value.
+* @param string &$cell_decorations
+*   Array of two strings, the first being the prefix for any contents
+*   of the table cell, the second being the suffix.
+* @param bool $force_display
+*   Flag indicating whether or not the cell created should not be empty.
+*   If true, the cell will have the appropriate contents; if false, then
+*   it will only be non-empty if its value differs from the previous
+*   call time's corresponding value.
+* @return bool
+*   True if the created cell is not empty, false if it is empty.
+*/
+function createCallTimeTableCell(
+    &$call_time,
+    &$last_call_time,
+    $index,
+    &$cell_decorations,
+    $force_display
+) {
+    if ($force_display || ($last_call_time[$index] != $call_time[$index])) {
+        echo "<td>". $cell_decorations[0]. $call_time[$index]. $cell_decorations[1]. "</td>";
+        return true;
+    } else {
+        echo "<td></td>";
+        return false;
+    }
+}
+
+/**
+* Create a call time table phone number cell, filling it with the value
+* found at the specified index of the specified call time array, with
+* said value being a link to interact with the phone number.
+*
+* @param array &$call_time
+*   Information about the call time from which to extract the relevant
+*   value.
+* @param array &$last_call_time
+*   Information about the previous call time; this is used to determine
+*   whether or not the value has changed from the last one, and if it
+*   has not, to create an empty table cell.
+* @param string $index
+*   Index into $call_time at which to find the relevant value.
+* @param string $cell_decorations
+*   Array of two strings, the first being the prefix for any contents
+*   of the table cell, the second being the suffix.
+* @param bool $force_display
+*   Flag indicating whether or not the cell created should not be empty.
+*   If true, the cell will have the appropriate contents; if false, then
+*   it will only be non-empty if its value differs from the previous
+*   call time's corresponding value.
+* @return bool
+*   True if the created cell is not empty, false if it is empty.
+*/
+function createCallTimeTablePhoneCell(
+    &$call_time,
+    &$last_call_time,
+    $index,
+    &$cell_decorations,
+    $force_display
+) {
+    if ($force_display || ($last_call_time[$index] != $call_time[$index])) {
+        echo "<td>". $cell_decorations[0]. getContactNumber($call_time[$index]).
+                $cell_decorations[1]. "</td>";
+        return true;
+    } else {
+        echo "<td></td>";
+        return false;
+    }
+}
+
+/**
+* Create the two (start and end) call time range table cells, placing within
+* them the values found at the appropriate indices of the specified call time
+* array.
+*
+* @param array &$call_time
+*   Information about the call time from which to extract the relevant
+*   values.
+* @param array &$last_call_time
+*   Information about the previous call time; this is used to determine
+*   whether or not the values changed from the last one, and if they have
+*   not, to create empty table cells.
+* @param string $start_index
+*   Index into $call_time at which to find the relevant start time value.
+* @param string $end_index
+*   Index into $call_time at which to find the relevant end time value.
+* @param string &$cell_decorations
+*   Array of two strings, the first being the prefix for any contents
+*   of the table cells, the second being the suffix.
+* @param bool $force_display
+*   Flag indicating whether or not the cells created should not be empty.
+*   If true, the cells will have the appropriate contents; if false, then
+*   they will only be non-empty if their values differ from the previous
+*   call time's corresponding values.
+* @return bool
+*   True if the created cell is not empty, false if it is empty.
+*/
+function createCallTimeRangeTableCells(
+    &$call_time,
+    &$last_call_time,
+    $start_index,
+    $end_index,
+    &$cell_decorations,
+    $force_display
+) {
+    if ($force_display || (($last_call_time[$start_index] != $call_time[$start_index]) ||
+         ($last_call_time[$end_index] != $call_time[$end_index]))) {
+        foreach (array($start_index, $end_index) as $index) {
+            echo "<td>". $cell_decorations[0]. getDisplayableTime($call_time[$index]).
+                    $cell_decorations[1]. "</td>";
+        }
+        return true;
+    } else {
+        echo "<td></td><td></td>";
+        return false;
+    }
+}
+
+/**
+* Create the call time types to be received table cell, placing within it
+* a concatenation of the values found at the appropriate indices of the
+* specified call time array.
+*
+* @param array &$call_time
+*   Information about the call time from which to extract the relevant
+*   values. Note that this array is modified to include an entry for the
+*   string that would be displayed in this cell (regardless of whether
+*   said string is actually displayed, since if it is the same as the one
+*   in $last_call_time, it obviously will not be). The entry is under the
+*   index 'types_string'.
+* @param array &$last_call_time
+*   Information about the previous call time; this is used to determine
+*   whether or not the values changed from the last one, and if they have
+*   not, to create empty table cells. This array must have an entry for
+*   'types_string'.
+* @param array $type_strings_for_indices
+*   Mapping of the indices of types to be received, all of which should
+*   be found within $call_time, to the text strings used to describe the
+*   types.
+* @param string &$cell_decorations
+*   Array of two strings, the first being the prefix for any contents
+*   of the table cell, the second being the suffix.
+* @param bool $force_display
+*   Flag indicating whether or not the cell created should not be empty.
+*   If true, the cell will have the appropriate contents; if false, then
+*   it will only be non-empty if its value differs from the previous
+*   call time's corresponding value.
+* @return bool
+*   True if the created cell is not empty, false if it is empty.
+*/
+function createCallTimeTypesTableCell(
+    &$call_time,
+    &$last_call_time,
+    $type_strings_for_indices,
+    &$cell_decorations,
+    $force_display
+) {
+    $types = array();
+    foreach ($type_strings_for_indices as $index => $string) {
+        if ($call_time[$index] == 'y') {
+            $types[] = $string;
+        }
+    }
+    $types_string = implode(', ', $types);
+    if ($force_display || ($last_call_time['types_string'] != $types_string)) {
+        echo "<td>". $cell_decorations[0]. $types_string. $cell_decorations[1]. "</td>";
+        $result = true;
+    } else {
+        echo "<td></td>";
+        $result = false;
+    }
+    $call_time['types_string'] = $types_string;
+    return $result;
+}
+
+/**
+* Add a single call time entry to the database.
+*
+* Data is passed from a modal form.
+*
+* @param array $call_time
+*   Call time form data.  Contains the following keys:
+*		'contact_id' => The contact id to add a call time to
+* 		'day' => 'all','weekdays','weekends','Sun','Mon','Tue','Wed','Thu','Fri','Sat'
+* 		'earliest' => The earliest time the contact should be called.
+*		'latest' => The latest time the contact should be called.
+*		'receive_texts' => Whether the contact should receive texts.
+*		'receive_calls' => Whether the contact should receive calls.
+*		'receive_call_answered_alerts' => Whether the contact should receive call answered alerts.
+* @param array $call_time_languages
+*   Call time languages array; each key is a language identifier, and the corresponding
+*   value is 'on' if that language is included.
+* @param string &$error
+*   Errors if any occurred.
+* @param string &$message
+*   An informational message if appropriate.
+* @return bool
+*   True if successful, false if an error occurred.
+*/
+function addCallTime($call_time, $call_time_languages, &$error, &$message)
+{
+    $error = '';
+    $message = '';
+
+    // call_time[]:
+
+
+    // contact id
+    $call_time['contact_id'] = (int)$call_time['contact_id'];
+    if (!$call_time['contact_id']) {
+        $error = "No contact was specified.";
+        return false;
+    }
+    // default day
+    if (!$call_time['day']) {
+        $call_time['day'] = 'all';
+    }
+    // default earliest time
+    if (!$call_time['earliest']) {
+        $call_time['earliest'] = '12:00 am';
+    }
+    // default latest time
+    if (!$call_time['latest']) {
+        $call_time['latest'] = '11:59 pm';
+    }
+    // list of languages
+    $languages = array();
+    foreach ($call_time_languages as $language => $include) {
+        if ($include == 'on') {
+            $languages[] = $language;
+        }
+    }
+    if (count($languages) == 0) {
+        $error = "The call time record could not be added because no ".
+                "language was specified.";
+        return false;
+    }
+
+    // Ensure at least one checkbox is selected (for texts, calls, or
+    // answered alerts.
+    $texts = (isset($call_time['texts']) && ($call_time['texts'] == 'on'));
+    $calls = (isset($call_time['calls']) && ($call_time['calls'] == 'on'));
+    $alerts = (isset($call_time['answered_alerts']) && ($call_time['answered_alerts'] == 'on'));
+    if (!$texts && !$calls && !$alerts) {
+        $error = "The call time record could not be added because no ".
+                "'received type' checkbox (texts, calls, or call ".
+                "answered alerts) was specified.";
+        return false;
+    }
+
+    // Add one call_times record for each language.
+    foreach ($languages as $language) {
+        $sql = "INSERT INTO call_times SET ".
+            "contact_id='".addslashes($call_time['contact_id'])."',".
+            "day='".addslashes($call_time['day'])."',".
+            "earliest='".addslashes(date("H:i:s", strtotime($call_time['earliest'])))."',".
+            "latest='".addslashes(date("H:i:s", strtotime($call_time['latest'])))."',".
+            "language_id='".addslashes($language)."',".
+            "receive_texts='". ($texts ? 'y' : 'n') . "',".
+            "receive_calls='". ($calls ? 'y' : 'n') . "',".
+            "receive_call_answered_alerts='". ($alerts ? 'y' : 'n') ."'";
+        if (!db_db_command($sql, $error)) {
+            return false;
+        }
+    }
+
+    $message = "The call time entry was added.";
+    return true;
+}
+/**
+* Edit a single call time entry in the database.
+*
+* Data is passed from a modal form.
+*
+* @param array $call_time
+*   Call time form data.  Contains the following keys:
+*       'id' => Original identifier of the call time entry being edited.
+* 		'day' => 'all','weekdays','weekends','Sun','Mon','Tue','Wed','Thu','Fri','Sat'.
+* 		'earliest' => The earliest time the contact should be called.
+*		'latest' => The latest time the contact should be called.
+*		'receive_texts' => Whether the contact should receive texts.
+*		'receive_calls' => Whether the contact should receive calls.
+*		'receive_call_answered_alerts' => Whether the contact should receive call
+*           answered alerts.
+* @param array $call_time_languages
+*   Call time languages array; each key is a language identifier, and the corresponding
+*   value is 'on' if that language is included. NOTE: This is ignored for now; at This
+*   time, languages cannot be edited, since only one entry is being edited for a call
+*   time, and the original call time may have had multiple entries created for it, one
+*   per language.
+* @param string &$error
+*   Errors if any occurred.
+* @param string &$message
+*   An informational message if appropriate.
+* @return bool
+*   True if successful, false if an error occurred.
+*/
+function editCallTime($call_time, $call_time_languages, &$error, &$message)
+{
+    $error = '';
+    $message = '';
+
+    // Update the day, earliest time, and latest time if each is provided.
+    $updates = array();
+    if ($call_time['day']) {
+        $updates[] = "day='". addslashes($call_time['day']). "'";
+    }
+    if ($call_time['earliest']) {
+        $updates[] = "earliest='". addslashes(date("H:i:s", strtotime($call_time['earliest']))). "'";
+    }
+    if ($call_time['latest']) {
+        $updates[] = "latest='". addslashes(date("H:i:s", strtotime($call_time['latest']))). "'";
+    }
+
+    // Ensure at least one checkbox is selected (for texts, calls, or
+    // answered alerts.
+    $texts = (isset($call_time['receive_texts']) && ($call_time['receive_texts'] == 'on'));
+    $calls = (isset($call_time['receive_calls']) && ($call_time['receive_calls'] == 'on'));
+    $alerts = (isset($call_time['receive_call_answered_alerts']) &&
+            ($call_time['receive_call_answered_alerts'] == 'on'));
+    if (!$texts && !$calls && !$alerts) {
+        $error = "The call time record could not be edited because no ".
+                "'received type' checkbox (texts, calls, or call ".
+                "answered alerts) was specified.";
+        return false;
+    }
+    $updates[] = "receive_texts='". ($texts ? "y" : "n")."', ".
+            "receive_calls='". ($calls ? "y" : "n")."', ".
+            "receive_call_answered_alerts='". ($alerts ? "y" : "n")."'";
+
+    // Do nothing if nothing has been found to update.
+    if (count($updates) == 0) {
+        $message = "The call time entry was not updated since no edits were specified.";
+        return true;
+    }
+
+    // Update the entry in the table.
+    $sql = "UPDATE call_times SET ". implode(", ", $updates). " WHERE id='".
+            addslashes($call_time['id']). "'";
+    if (!db_db_command($sql, $error)) {
+        return false;
+    }
+
+    $message = "The call time entry was updated.";
+
+    return true;
+}
+
+/**
+* Remove a call time entry from the database
+*
+* ...
+*
+* @param int $id
+*   Call time id to remove.
+* @param string &$error
+*   Errors if any occurred.
+* @param string &$message
+*   An informational message if appropriate.
+*
+* @return bool
+*   True unless an error occurred.
+*/
+function removeCallTime($id, &$error, &$message)
+{
+    $sql = "DELETE FROM call_times WHERE id='".addslashes($id)."'";
+    if (!db_db_command($sql, $error)) {
+        return false;
+    }
+
+    $message = "The record was removed.";
+    return true;
+}

--- a/hotline_languages.php
+++ b/hotline_languages.php
@@ -3,7 +3,7 @@
 * @file
 * List of languages supported
 *
-* 
+*
 */
 
 require_once 'config.php';
@@ -12,19 +12,20 @@ require_once $LIB_BASE . 'lib_sms.php';
 include 'header.php';
 
 if (!db_db_query("SELECT * FROM languages ORDER BY keypress", $languages, $error)) {
-?><div class="alert alert-danger" role="alert"><?php echo $error ?></div><?php
+    ?><div class="alert alert-danger" role="alert"><?php echo $error ?></div><?php
 }
 
 ?>
 		  <h2 class="sub-header">Hotline</h2>
    		    <ul class="nav nav-pills">
+              <li role="presentation"><a href="hotline_active_calls.php">Active Calls</a></li>
 			  <li role="presentation"><a href="hotline_staff.php">Staff</a></li>
 			  <li role="presentation"><a href="hotline_blocks.php">Blocks</a></li>
 			  <li role="presentation" class="active"><a href="hotline_languages.php">Languages</a></li>
 			  <li role="presentation"><a href="log.php?ph=<?php echo sms_getFirstHotline($hotline_number, $hotline, $error) ? urlencode($hotline_number) : '' ?>">Log</a></li>
 		    </ul>
 		    <br />
-		    
+
           <h2 class="sub-header">Languages</h2>
           <div class="table-responsive">
             <table class="table table-striped">
@@ -41,7 +42,7 @@ if (!db_db_query("SELECT * FROM languages ORDER BY keypress", $languages, $error
               <tbody>
 <?php
 foreach ($languages as $language) {
-?>
+    ?>
                 <tr>
 				  <td><?php echo $language['keypress']?></td>
                   <td><?php echo $language['language']?></td>

--- a/hotline_staff.php
+++ b/hotline_staff.php
@@ -4,11 +4,13 @@
 * Staff
 *
 * Display and edit hotline staff on duty now, and all staff
-* 
+*
 */
 
 require_once 'config.php';
 require_once $LIB_BASE . 'lib_sms.php';
+
+require_once 'hotline_call_times_utils.php';
 
 include 'header.php';
 
@@ -17,120 +19,50 @@ $action = isset($_REQUEST['action']) ? $_REQUEST['action'] : '';
 $staff = isset($_POST['staff']) ? $_POST['staff'] : '';
 $id = isset($_REQUEST['id']) ? $_REQUEST['id'] : '';
 $call_time = isset($_REQUEST['call_time']) ? $_REQUEST['call_time'] : '';
+$call_time_languages = isset($_REQUEST['call_time_languages']) ? $_REQUEST['call_time_languages'] : array();
+$display_type = isset($_REQUEST['display_type']) ? $_REQUEST['display_type'] : 'chronological';
 
 // Authorized user?
-$authorized = empty($HOTLINE_AUTHORIZED_USERS) || 
-	in_array($_SERVER['PHP_AUTH_USER'], $HOTLINE_AUTHORIZED_USERS);
+$authorized = empty($HOTLINE_AUTHORIZED_USERS) ||
+    in_array($_SERVER['PHP_AUTH_USER'], $HOTLINE_AUTHORIZED_USERS);
 if (!$authorized) {
-	// no
-	$error = "You are not authorized to update staff information.";
+    // no
+    $error = "You are not authorized to update staff information.";
 }
 
 // *** ACTIONS ***
 
-// quick add?
+// Add or remove a staff member, or add, edit, or remove a call time, or put up
+// a modal dialog to allow the user to add a new call time or edit an existing
+// one, if any of these actions were requested.
 if ($action == 'add' && $authorized) {
-	addStaff($staff, $error, $success);
-// remove staff?
-} else if ($action == 'removestaff' && $authorized) {
-	removeStaff($id, $error, $success);
-// remove call time?
-} else if ($action == 'removecalltime' && $authorized) {
-	removeCallTime($id, $error, $success);
-// add a call time?
-} else if ($action == 'addcalltime' && $authorized) {
-	addCallTime($call_time, $error, $message);
-}
-
-// display add call time modal?
-if ($action == 'calltimemodal') {
-	// look up the name of the contact
-	$sql = "SELECT contact_name FROM contacts WHERE id='".addslashes($id)."'";
-	db_db_getone($sql, $contact_name, $error);
-?>
-		<div class="modal show" tabindex="-1" role="dialog">
-		  <div class="modal-dialog" role="document">
-			<div class="modal-content">
-			  <form id="add-calltime" action="hotline_staff.php" method="POST">
-			   <input type="hidden" name="action" value="addcalltime">
-			   <input type="hidden" name="call_time[id]" value="<?php echo $id ?>">
-			    <div class="modal-header">
-				  <a class="btn close" href="hotline_staff.php" role="button" aria-label="Close"><span aria-hidden="true">&times;</span></a>
-				  <h4 class="modal-title"><strong>Add a call time for <?php echo $contact_name ?></strong></h4>
-			    </div>
-			    <div class="modal-body">
-				  <div class="form-group">
-					<label for="calltime_day">Days</label>
-					<select class="form-control" id="calltime_day" name="call_time[day]">
-					  <option>all</option>
-					  <option>weekdays</option>
-					  <option>weekends</option>
-					  <option>Sun</option>
-					  <option>Mon</option>
-					  <option>Tue</option>
-					  <option>Wed</option>
-					  <option>Thu</option>
-					  <option>Fri</option>
-					  <option>Sat</option>
-					</select>
-				  </div>
-				  <div class="form-group">
-					<label for="calltime_earliest">Earliest time</label>
-					<input type="text" class="form-control" id="calltime_earliest" name="call_time[earliest]" value="12:00 am">
-				  </div>
-				  <div class="form-group">
-					<label for="calltime_latest">Latest time</label>
-					<input type="text" class="form-control" id="calltime_latest" name="call_time[latest]" value="11:59 pm">
-				  </div>
-				  <div class="form-group">
-					<label for="calltime_language_id">Language</label>
-					<select class="form-control" id="calltime_language_id" name="call_time[language_id]">
-<?php
-	// look up the language options
-	$sql = "SELECT id,language FROM languages ORDER BY language";
-	db_db_query($sql, $languages, $error);
-	foreach ($languages as $language) {
-?>
-					  <option value="<?php echo $language['id'] ?>"><?php echo $language['language'] ?></option>
-<?php
-	}
-?>
-					</select>
-				  </div>
-				  <div class="form-group">
-					<label for="calltime_texts">Receive: </label>
-					<label class="checkbox-inline">
-					  <input type="checkbox" id="calltime_texts" name="call_time[texts]" checked> texts
-					</label>
-					<label class="checkbox-inline">
-					  <input type="checkbox" id="calltime_calls" name="call_time[calls]" checked> calls
-					</label>
-					<label class="checkbox-inline">
-					  <input type="checkbox" id="calltime_answered_alerts" name="call_time[answered_alerts]"> call answered alerts
-					</label>
-				  </div>
-			    </div>
-			    <div class="modal-footer">
-				  <a class="btn btn-default" href="hotline_staff.php" role="button">Close</a>
-				  <button type="submit" class="btn btn-primary">Add</button>
-			    </div>
-			  </form>
-			</div><!-- /.modal-content -->
-		  </div><!-- /.modal-dialog -->
-		</div><!-- /.modal -->
-<?php
+    addStaff($staff, $error, $success);
+} elseif ($action == 'removestaff' && $authorized) {
+    removeStaff($id, $error, $success);
+} elseif ($action == 'addcalltime' && $authorized) {
+    addCallTime($call_time, $call_time_languages, $error, $success);
+} elseif ($action == 'editcalltime' && $authorized) {
+    editCallTime($call_time, $call_time_languages, $error, $success);
+} elseif ($action == 'removecalltime' && $authorized) {
+    removeCallTime($id, $error, $success);
+} elseif ($action == 'addcalltimemodal' && $authorized) {
+    $modal_action = "Add";
+    require 'hotline_call_times_modal.php';
+} elseif ($action == 'editcalltimemodal' && $authorized) {
+    $modal_action = "Edit";
+    require 'hotline_call_times_modal.php';
 }
 
 // any error message?
 if (!empty($error)) {
-?>
+    ?>
 	      <div class="alert alert-danger" role="alert"><?php echo $error ?></div>
 <?php
 }
 
 // any success message?
 if (!empty($success)) {
-?>
+    ?>
 	      <div class="alert alert-success" role="alert"><?php echo $success ?></div>
 <?php
 }
@@ -155,7 +87,7 @@ foreach ($HOTLINES as $hotline_number => $hotline) {
 }
 
 if (count($calls)) {
-?>          
+    ?>
         <h3 class="sub-header">Active calls</h3>
 		  <div class="table-responsive">
             <table class="table table-striped">
@@ -169,23 +101,19 @@ if (count($calls)) {
               </thead>
               <tbody>
 <?php
-	foreach ($calls as $call) {
-		$duration = strtotime($call['EndTime']) - strtotime($call['StartTime']);
-?>
+    foreach ($calls as $call) {
+        $duration = strtotime($call['EndTime']) - strtotime($call['StartTime']); ?>
                 <tr>
                   <td><?php
-                  echo '<a href="contact.php?ph=' . urlencode($call['From']) . '">' . $call['From'] . '</a>';
-                  ?></td>
+                  echo '<a href="contact.php?ph=' . urlencode($call['From']) . '">' . $call['From'] . '</a>'; ?></td>
                   <td><?php
-                  echo '<a href="contact.php?ph=' . urlencode($call['To']) . '">' . $call['To'] . '</a>';
-                  ?></td>
+                  echo '<a href="contact.php?ph=' . urlencode($call['To']) . '">' . $call['To'] . '</a>'; ?></td>
                   <td><?php echo $call['Status']?></td>
-                  <td><?php echo date("m/d/y h:i a", strtotime($call['StartTime'])) . 
-								 ' (' . $duration . ' seconds)' ?></td>
+                  <td><?php echo date("m/d/y h:i a", strtotime($call['StartTime'])) .
+                                 ' (' . $duration . ' seconds)' ?></td>
                 </tr>
 <?php
-	}
-?>
+    } ?>
               </tbody>
             </table>
           </div>
@@ -205,444 +133,258 @@ if (count($calls)) {
                 </tr>
               </thead>
               <tbody>
-<?php
+                <?php
+
 $receives = array('calls' => false, 'texts' => false, 'answered_alerts' => false);
 sms_getActiveContacts($contacts, 0 /* any language */, $receives, $error);
 foreach ($contacts as $contact) {
-	$display = array();
-	// receive texts?
-	if ($contact['receive_texts'] == 'y') {
-		$display[] = "texts";
-	}
-	// receive calls?
-	if ($contact['receive_calls'] == 'y') {
-		$display[] = "calls";
-	}
-	// receive call answered alerts?
-	if ($contact['receive_call_answered_alerts'] == 'y') {
-		$display[] = "answer alerts";
-	}			
-?>
-                <tr>
-                  <td><?php echo $contact['contact_name']?></td>
-                  <td><?php
-                  echo '<a href="contact.php?ph=' . urlencode($contact['phone']) . '">' . $contact['phone'] . '</a>';
-                  ?></td>
-                  <td><?php echo implode(', ', $display) ?></td>
-                </tr>
-<?php
-}
-?>
-              </tbody>
-            </table>
-          </div>
-
-<?php
-
-// All hotline staff
-if (!db_db_query("SELECT * FROM contacts ORDER BY contact_name", $contacts, $error)) {
-    echo $error;
-}
-
-?>
-          <h3 class="sub-header">Staff</h3>
-          <div class="table-responsive">
-            <table class="table table-striped">
-              <thead>
-                <tr>
-                  <th>name</th>
-                  <th>phone</th>
-                  <th>call times</th>
-                </tr>
-              </thead>
-              <tbody>
-<?php
-foreach ($contacts as $contact) {
-    $sql = "SELECT call_times.*,languages.language FROM call_times ".
-		"LEFT JOIN languages ON languages.id = call_times.language_id ".
-        "WHERE contact_id='{$contact['id']}' ".
-        "ORDER BY call_times.day, call_times.earliest, call_times.latest, languages.language";
-    if (!db_db_query($sql, $call_times, $error)) {
-        echo $error;
+    $types = array();
+    // receive texts?
+    if ($contact['receive_texts'] == 'y') {
+        $types[] = "texts";
     }
-?>
+    // receive calls?
+    if ($contact['receive_calls'] == 'y') {
+        $types[] = "calls";
+    }
+    // receive call answered alerts?
+    if ($contact['receive_call_answered_alerts'] == 'y') {
+        $types[] = "answer alerts";
+    } ?>
                 <tr>
                   <td><?php echo $contact['contact_name']?></td>
-                  <td><?php 
-                  echo '<a href="contact.php?ph=' . urlencode($contact['phone']) . '">' . $contact['phone'] . '</a>';
-                  ?></td>
                   <td><?php
-    // allow removal of staff entry if all call time records are removed
-    if (count($call_times) == 0) {
-?>
-		<a href="hotline_staff.php?action=removestaff&id=<?php echo $contact['id'] ?>" 
-		   onClick="return confirm('Are you sure you want to remove this staff entry?');">
-		 <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
-<?php
-	} else {
-		// display each call_times records, crossed out if disabled
-		foreach ($call_times as $call_time) {
-			if ($call_time['enabled'] == 'n') {
-				echo "<s>";
-			}
-			// days and times
-			$display = array("day: {$call_time['day']}",
-				"time: ". date("h:i a", strtotime($call_time['earliest'])) . " to ".
-					date("h:i a", strtotime($call_time['latest'])) .", {$call_time['language']}"
-			);
-			// receive texts?
-			if ($call_time['receive_texts'] == 'y') {
-				$display[] = "texts";
-			}
-			// receive calls?
-			if ($call_time['receive_calls'] == 'y') {
-				$display[] = "calls";
-			}
-			// receive call answered alerts?
-			if ($call_time['receive_call_answered_alerts'] == 'y') {
-				$display[] = "answer alerts";
-			}			
-			echo implode(', ', $display);
-			if ($call_time['enabled'] == 'n') {
-				echo "</s>";
-			}
-?>
-		<a href="hotline_staff.php?action=removecalltime&id=<?php echo $call_time['id'] ?>" 
-		   onClick="return confirm('Are you sure you want to remove this record?');">
-		 <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
-<?php
-			echo "<br />\n";
-		}
-	}
-?>
-		<a href="hotline_staff.php?action=calltimemodal&id=<?php echo $contact['id'] ?>">
-		 <span class="glyphicon glyphicon-plus" aria-hidden="true"></span></a>
-		
-                  </td>
+                  echo '<a href="contact.php?ph=' . urlencode($contact['phone']) . '">' . $contact['phone'] . '</a>'; ?></td>
+                  <td><?php echo implode(', ', $types) ?></td>
                 </tr>
 <?php
+
+// End of foreach loop; iteration through contacts is done.
 }
+
 ?>
               </tbody>
             </table>
           </div>
+
+          <?php
+
+// Get the call times in chronological or alphabetical order and display them
+// as appropriate.
+if ($display_type == "chronological") {
+    require 'hotline_call_times_chrono.php';
+} else {
+    require 'hotline_call_times_alpha.php';
+}
+
+          ?>
           <form id="text-controls" action="hotline_staff.php" method="POST">
-		   <input type="hidden" name="action" value="add">
-		   <div class="form-group">
-			<label for="text-message">Add staff</label>
-			<textarea class="form-control" name="staff" rows="3" cols="30"></textarea>
-			<p class="help-block">
-			  <b>Format:</b> name, phone number, day, earliest time, latest time, language 
-				keypress, texts (0 or 1), calls (0 or 1), call answered alerts (0 or 1).
-			  Only name and phone number required.
-			</p>
- 		   </div>		 
-		   <button class="btn btn-success" id="button-text">Add</button>
+		    <input type="hidden" name="action" value="add">
+            <input type="hidden" name="display_type" value="<?php echo $display_type ?>">
+		    <div class="form-group">
+			  <label for="text-message">Add staff</label>
+			  <textarea class="form-control" name="staff" rows="3" cols="30"></textarea>
+			  <p class="help-block">
+			    <b>Format:</b> name, phone number, day, earliest time, latest time, language
+				    keypress, texts (0 or 1), calls (0 or 1), call answered alerts (0 or 1).
+			        Only name and phone number required.
+			  </p>
+ 		    </div>
+		    <button class="btn btn-success" id="button-text">Add</button>
 		  </form>
-<?php
+          <?php
 include 'footer.php';
 
 /**
 * Add staff to the database
 *
-* Each entry is separated by a newline.  Format: 
+* Each entry is separated by a newline.  Format:
 *    name,phone number,day,earliest time,latest time,language id,texts (0 or 1).
-* 
+*
 * @param array $staff
 *   List of staff to add, one on each line.
 * @param string &$error
 *   Errors if any occurred.
 * @param string &$message
 *   An informational message if appropriate.
-*   
+*
 * @return bool
 *   True if any staff were provided.
 */
-
 function addStaff($staff, &$error, &$message)
 {
-	$error = '';
-	$message = '';
-	
-	// break apart the staff into an array
-	$staff_lines = explode("\n", trim($staff));
-	if (count($staff_lines) == 0) {
-		$error = "No staff to import.";
-		return false;
-	}
-	
-	// iterate through each staff entry
-	$success_count = 0;
-	foreach ($staff_lines as $staff_line) {
-		if (!trim($staff_line)) {
-			continue;
-		}
-		
-		$staff_array = explode(",", trim($staff_line));
-		
-		// 0 = name
-		// 1 = phone number
-		// 2 = day
-		// 3 = earliest time
-		// 4 = latest time
-		// 5 = language keypress
-		// 6 = texts (0 or 1).
-		// 7 = calls (0 or 1).
-		// 8 = call answered alerts (0 or 1).
-		
-		// make sure the number is in E164 format
-		if (!sms_normalizePhoneNumber($staff_array[1], $n_error)) {
-			$error .= "{$staff_line}: " . $n_error . "<br />\n";
-			continue;
-		}
-		
-		// name?
-		if (!trim($staff_array[0])) {
-			$error .= "{$staff_line}: No name provided.<br />\n";
-			continue;
-		}
-		
-		// is this number in the database already?
-		$sql = "SELECT * FROM contacts WHERE phone='".addslashes($staff_array[1])."'";
-		if (!db_db_getrow($sql, $contact, $db_error)) {
-			$error .= "{$staff_line}: {$db_error}<br />\n";
-			continue;
-		}
-		if ($contact['id']) {
-			// it's already in the database, update the name
-			$sql = "UPDATE contacts SET contact_name='".addslashes(trim($staff_array[0]))."' ".
-				"WHERE id='{$contact['id']}'";
-			if (!db_db_command($sql, $db_error)) {
-				$error .= "{$staff_line}: {$db_error}<br />\n";
-				continue;
-			}
-		} else {
-			// it's not in the database, add it
-			$sql = "INSERT INTO contacts SET contact_name='".addslashes(trim($staff_array[0]))."',".
-				"phone='".addslashes($staff_array[1])."'";
-			if (!db_db_command($sql, $db_error)) {
-				$error .= "{$staff_line}: {$db_error}<br />\n";
-				continue;
-			}
-			// retrieve the newly added record
-			$sql = "SELECT * FROM contacts WHERE phone='".addslashes($staff_array[1])."'";
-			if (!db_db_getrow($sql, $contact, $db_error)) {
-				$error .= "{$staff_line}: {$db_error}<br />\n";
-				continue;
-			}
-		}
+    $error = '';
+    $message = '';
 
-		// is a day provided?
-		if (trim($staff_array[2])) {
-			// provide defaults
-			if (!$staff_array[3]) {
-				// default earliest time
-				$staff_array[3] = '12:00 am';
-			}
-			if (!$staff_array[4]) {
-				// default latest time
-				$staff_array[4] = '11:59 pm';
-			}
-			if (!$staff_array[5]) {
-				// default language keypress
-				$staff_array[5] = 2;
-			}
-			if ($staff_array[6] == '') {
-				// default to sending texts
-				$staff_array[6] = 1;
-			}
-			if ($staff_array[7] == '') {
-				// default to receiving calls
-				$staff_array[7] = 1;
-			}
-			if ($staff_array[8] == '') {
-				// default to not sending call answered alerts
-				$staff_array[8] = 0;
-			}
-			
-		    // get language_id from the language_keypress
-		    $language_id = "1";
-		    $sql = "SELECT id FROM languages WHERE keypress='". addslashes($staff_array[5]) . "'";
-		    if (!db_db_getone($sql, $language_id, $db_error)){
-		        $error = "{$staff_line}: {$db_error}<br />\n";
-		        continue;
-		    }
+    // break apart the staff into an array
+    $staff_lines = explode("\n", trim($staff));
+    if (count($staff_lines) == 0) {
+        $error = "No staff to import.";
+        return false;
+    }
 
-			// add a call_times record
-			$sql = "INSERT INTO call_times SET ".
-				"contact_id='".addslashes($contact['id'])."',".
-				"day='".trim(addslashes($staff_array[2]))."',".
-				"earliest='".addslashes(date("H:i:s", strtotime($staff_array[3])))."',".
-				"latest='".addslashes(date("H:i:s", strtotime($staff_array[4])))."',".
-				"language_id='".addslashes($language_id)."',".
-				"receive_texts='". ($staff_array[6] ? 'y' : 'n') . "',".
-				"receive_calls='". ($staff_array[7] ? 'y' : 'n') . "',".
-				"receive_call_answered_alerts='". ($staff_array[8] ? 'y' : 'n') . "'";
-			if (!db_db_command($sql, $db_error)) {
-				$error .= "{$staff_line}: {$db_error}<br />\n";
-				continue;
-			}
-		}
-		
-		// import successful
-		$success_count++;
-	}
-	
-	// report on the status of the import
-	$error_count = count($staff_lines) - $success_count;
-	$message = "Imported {$success_count} staff entries successfully. ";
-	if ($error_count) {
-		$message .= "{$error_count} staff entries had errors.";
-	}
-	
-	return true;
-}
+    // iterate through each staff entry
+    $success_count = 0;
+    foreach ($staff_lines as $staff_line) {
+        if (!trim($staff_line)) {
+            continue;
+        }
 
-/**
-* Add a single call time entry to the database
-*
-* Data is passed from a modal form.
-* 
-* @param array $call_time
-*   Call time form data.  Contains the following keys:
-*		'id' => The contact id to add a call time to
-* 		'day' => 'all','weekdays','weekends','Sun','Mon','Tue','Wed','Thu','Fri','Sat'
-* 		'earliest' => The earliest time the contact should be called.
-*		'latest' => The latest time the contact should be called.
-*		'language_id' => The supported language.
-*		'texts' => Whether the contact should receive texts.
-*		'calls' => Whether the contact should receive calls.
-*		'answered_alerts' => Whether the contact should receive call answered alerts.
-* @param string &$error
-*   Errors if any occurred.
-* @param string &$message
-*   An informational message if appropriate.
-*   
-* @return bool
-*   True unless an error occurred.
-*/
+        $staff_array = explode(",", trim($staff_line));
 
-function addCallTime($call_time, &$error, &$message)
-{
-	$error = '';
-	$message = '';
-	
-	// call_time[]:
-	
-	
-	// contact id
-	$call_time['id'] = (int)$call_time['id'];
-	if (!$call_time['id']) {
-		$error = "No contact was specified.";
-		return false;
-	}
-	// default day
-	if (!$call_time['day']) {
-		$call_time['day'] = 'all';
-	}
-	// default earliest time
-	if (!$call_time['earliest']) {
-		$call_time['earliest'] = '12:00 am';
-	}
-	// default latest time
-	if (!$call_time['latest']) {
-		$call_time['latest'] = '11:59 pm';
-	}
-	// language id
-	$call_time['language_id'] = (int)$call_time['language_id'];
-	if (!$call_time['language_id']) {
-		$error = "No language was specified.";
-		return false;
-	}
+        // 0 = name
+        // 1 = phone number
+        // 2 = day
+        // 3 = earliest time
+        // 4 = latest time
+        // 5 = language keypress
+        // 6 = texts (0 or 1).
+        // 7 = calls (0 or 1).
+        // 8 = call answered alerts (0 or 1).
 
-	// Ensure at least one checkbox is selected (for texts, calls, or
-	// answered alerts.
-	if (($call_time['texts'] != 'on') && ($call_time['calls'] != 'on') && ($call_time['answered_alerts'] != 'on')) {
-		$error = "No received type checkbox (texts, calls, or call answered alerts) was specified.";
-		return false;
-	}
+        // make sure the number is in E164 format
+        if (!sms_normalizePhoneNumber($staff_array[1], $n_error)) {
+            $error .= "{$staff_line}: " . $n_error . "<br />\n";
+            continue;
+        }
 
-	// add a call_times record
-	$sql = "INSERT INTO call_times SET ".
-		"contact_id='".addslashes($call_time['id'])."',".
-		"day='".addslashes($call_time['day'])."',".
-		"earliest='".addslashes(date("H:i:s", strtotime($call_time['earliest'])))."',".
-		"latest='".addslashes(date("H:i:s", strtotime($call_time['latest'])))."',".
-		"language_id='".addslashes($call_time['language_id'])."',".
-		"receive_texts='". (($call_time['texts'] == 'on') ? 'y' : 'n') . "',".
-		"receive_calls='". (($call_time['calls'] == 'on') ? 'y' : 'n') . "',".
-		"receive_call_answered_alerts='". (($call_time['answered_alerts'] == 'on') ? 'y' : 'n') ."'";
-	if (!db_db_command($sql, $error)) {
-		return false;
-	}
+        // name?
+        if (!trim($staff_array[0])) {
+            $error .= "{$staff_line}: No name provided.<br />\n";
+            continue;
+        }
 
-	$message = "The call time entry was added.";
-	return true;
+        // is this number in the database already?
+        $sql = "SELECT * FROM contacts WHERE phone='".addslashes($staff_array[1])."'";
+        if (!db_db_getrow($sql, $contact, $db_error)) {
+            $error .= "{$staff_line}: {$db_error}<br />\n";
+            continue;
+        }
+        if ($contact['id']) {
+            // it's already in the database, update the name
+            $sql = "UPDATE contacts SET contact_name='".addslashes(trim($staff_array[0]))."' ".
+                "WHERE id='{$contact['id']}'";
+            if (!db_db_command($sql, $db_error)) {
+                $error .= "{$staff_line}: {$db_error}<br />\n";
+                continue;
+            }
+        } else {
+            // it's not in the database, add it
+            $sql = "INSERT INTO contacts SET contact_name='".addslashes(trim($staff_array[0]))."',".
+                "phone='".addslashes($staff_array[1])."'";
+            if (!db_db_command($sql, $db_error)) {
+                $error .= "{$staff_line}: {$db_error}<br />\n";
+                continue;
+            }
+            // retrieve the newly added record
+            $sql = "SELECT * FROM contacts WHERE phone='".addslashes($staff_array[1])."'";
+            if (!db_db_getrow($sql, $contact, $db_error)) {
+                $error .= "{$staff_line}: {$db_error}<br />\n";
+                continue;
+            }
+        }
+
+        // is a day provided?
+        if (isset($staff_array[2]) && trim($staff_array[2])) {
+            // provide defaults
+            if (!$staff_array[3]) {
+                // default earliest time
+                $staff_array[3] = '12:00 am';
+            }
+            if (!$staff_array[4]) {
+                // default latest time
+                $staff_array[4] = '11:59 pm';
+            }
+            if (!$staff_array[5]) {
+                // default language keypress
+                $staff_array[5] = 2;
+            }
+            if ($staff_array[6] == '') {
+                // default to sending texts
+                $staff_array[6] = 1;
+            }
+            if ($staff_array[7] == '') {
+                // default to receiving calls
+                $staff_array[7] = 1;
+            }
+            if ($staff_array[8] == '') {
+                // default to not sending call answered alerts
+                $staff_array[8] = 0;
+            }
+
+            // get language_id from the language_keypress
+            $language_id = "1";
+            $sql = "SELECT id FROM languages WHERE keypress='". addslashes($staff_array[5]) . "'";
+            if (!db_db_getone($sql, $language_id, $db_error)) {
+                $error = "{$staff_line}: {$db_error}<br />\n";
+                continue;
+            }
+
+            // add a call_times record
+            $sql = "INSERT INTO call_times SET ".
+                "contact_id='".addslashes($contact['id'])."',".
+                "day='".trim(addslashes($staff_array[2]))."',".
+                "earliest='".addslashes(date("H:i:s", strtotime($staff_array[3])))."',".
+                "latest='".addslashes(date("H:i:s", strtotime($staff_array[4])))."',".
+                "language_id='".addslashes($language_id)."',".
+                "receive_texts='". ($staff_array[6] ? 'y' : 'n') . "',".
+                "receive_calls='". ($staff_array[7] ? 'y' : 'n') . "',".
+                "receive_call_answered_alerts='". ($staff_array[8] ? 'y' : 'n') . "'";
+            if (!db_db_command($sql, $db_error)) {
+                $error .= "{$staff_line}: {$db_error}<br />\n";
+                continue;
+            }
+        }
+
+        // import successful
+        $success_count++;
+    }
+
+    // report on the status of the import
+    $error_count = count($staff_lines) - $success_count;
+    $message = "Imported {$success_count} staff entries successfully. ";
+    if ($error_count) {
+        $message .= "{$error_count} staff entries had errors.";
+    }
+
+    return true;
 }
 
 /**
 * Remove a staff entry from the database
 *
 * First make sure all call time entries have been removed.
-* 
+*
 * @param int $id
 *   Staff id to remove.
 * @param string &$error
 *   Errors if any occurred.
 * @param string &$message
 *   An informational message if appropriate.
-*   
+*
 * @return bool
 *   True unless an error occurred.
 */
-
 function removeStaff($id, &$error, &$message)
 {
-	// are all call time entries removed?
-	$sql = "SELECT COUNT(*) FROM call_times WHERE contact_id='".addslashes($id)."'";
-	if (!db_db_getone($sql, $call_time_count, $error)) {
-		return false;
-	}
-	if ($call_time_count) {
-		$error = "Please remove the call time entries first.";
-		return false;
-	}
-	
-	// delete the staff entry
-	$sql = "DELETE FROM contacts WHERE id='".addslashes($id)."'";
-	if (!db_db_command($sql, $error)) {
-		return false;
-	}
-	
-	$message = "The staff entry was removed.";
-	return true;
+    // are all call time entries removed?
+    $sql = "SELECT COUNT(*) FROM call_times WHERE contact_id='".addslashes($id)."'";
+    if (!db_db_getone($sql, $call_time_count, $error)) {
+        return false;
+    }
+    if ($call_time_count) {
+        $error = "Please remove the call time entries first.";
+        return false;
+    }
+
+    // delete the staff entry
+    $sql = "DELETE FROM contacts WHERE id='".addslashes($id)."'";
+    if (!db_db_command($sql, $error)) {
+        return false;
+    }
+
+    $message = "The staff entry was removed.";
+    return true;
 }
 
-/**
-* Remove a call time entry from the database
-*
-* ...
-* 
-* @param int $id
-*   Call time id to remove.
-* @param string &$error
-*   Errors if any occurred.
-* @param string &$message
-*   An informational message if appropriate.
-*   
-* @return bool
-*   True unless an error occurred.
-*/
-
-function removeCallTime($id, &$error, &$message)
-{
-	$sql = "DELETE FROM call_times WHERE id='".addslashes($id)."'";
-	if (!db_db_command($sql, $error)) {
-		return false;
-	}
-	
-	$message = "The record was removed.";
-	return true;
-}
-
-?>
+          ?>

--- a/hotline_staff.php
+++ b/hotline_staff.php
@@ -3,7 +3,7 @@
 * @file
 * Staff
 *
-* Display and edit hotline staff on duty now, and all staff
+* Display and edit all hotline staff and their call times
 *
 */
 
@@ -70,6 +70,7 @@ if (!empty($success)) {
 ?>
 		<h2 class="sub-header">Hotline</h2>
    		  <ul class="nav nav-pills">
+            <li role="presentation"><a href="hotline_active_calls.php">Active Calls</a></li>
 			<li role="presentation" class="active"><a href="hotline_staff.php">Staff</a></li>
 			<li role="presentation"><a href="hotline_blocks.php">Blocks</a></li>
 			<li role="presentation"><a href="hotline_languages.php">Languages</a></li>
@@ -78,47 +79,6 @@ if (!empty($success)) {
 		  <br />
 <?php
 
-// Active calls from and to the hotlines
-$calls = array();
-foreach ($HOTLINES as $hotline_number => $hotline) {
-	sms_getActiveCalls($hotline_number, '', $calls_from, $error);
-	sms_getActiveCalls('', $hotline_number, $calls_to, $error);
-	$calls = array_merge($calls_from, $calls_to, $calls);
-}
-
-if (count($calls)) {
-    ?>
-        <h3 class="sub-header">Active calls</h3>
-		  <div class="table-responsive">
-            <table class="table table-striped">
-              <thead>
-                <tr>
-                  <th>from</th>
-                  <th>to</th>
-                  <th>status</th>
-                  <th>timing</th>
-                </tr>
-              </thead>
-              <tbody>
-<?php
-    foreach ($calls as $call) {
-        $duration = strtotime($call['EndTime']) - strtotime($call['StartTime']); ?>
-                <tr>
-                  <td><?php
-                  echo '<a href="contact.php?ph=' . urlencode($call['From']) . '">' . $call['From'] . '</a>'; ?></td>
-                  <td><?php
-                  echo '<a href="contact.php?ph=' . urlencode($call['To']) . '">' . $call['To'] . '</a>'; ?></td>
-                  <td><?php echo $call['Status']?></td>
-                  <td><?php echo date("m/d/y h:i a", strtotime($call['StartTime'])) .
-                                 ' (' . $duration . ' seconds)' ?></td>
-                </tr>
-<?php
-    } ?>
-              </tbody>
-            </table>
-          </div>
-<?php
-}
 
 // On duty now
 ?>

--- a/lib/lib_db.php
+++ b/lib/lib_db.php
@@ -4,7 +4,7 @@
 * Library of database and other common functions.
 *
 * Automatically included from config.php
-* 
+*
 */
 
 /**
@@ -26,11 +26,15 @@ function db_databaseConnect()
     }
 
     // mysqli
-    $db = new mysqli($HOTLINE_DB_HOSTNAME, $HOTLINE_DB_USERNAME, 
-					 $HOTLINE_DB_PASSWORD, $HOTLINE_DB_DATABASE);
+    $db = new mysqli(
+        $HOTLINE_DB_HOSTNAME,
+        $HOTLINE_DB_USERNAME,
+                     $HOTLINE_DB_PASSWORD,
+        $HOTLINE_DB_DATABASE
+    );
 
     if ($db->connect_errno) {
-        die ($db->connect_error);
+        die($db->connect_error);
     }
 }
 
@@ -44,12 +48,12 @@ function db_databaseConnect()
 function db_databaseDisconnect()
 {
     global $db;
-	
-	if (!$db) {
-		// not connected
-		return;
-	}
-	
+
+    if (!$db) {
+        // not connected
+        return;
+    }
+
     // disconnect from the database
     $db->close();
 }
@@ -58,20 +62,20 @@ function db_databaseDisconnect()
 * Records an error
 *
 * Records an error in the error_log table.
-* 
+*
 * @param string $description
 *   Error description.
 * @param string $severity
 *   One of 'notice', 'warning', 'error', or 'critical'.
-*   
+*
 * @return bool
 *   True if recorded successfully
 */
 
 function db_error($description, $severity = 'error')
 {
-	$admin_user = $_SERVER['PHP_AUTH_USER'] ? $_SERVER['PHP_AUTH_USER'] : $_SERVER['REMOTE_USER'];
-	
+    $admin_user = $_SERVER['PHP_AUTH_USER'] ? $_SERVER['PHP_AUTH_USER'] : $_SERVER['REMOTE_USER'];
+
     $sql = "INSERT INTO errors SET ".
         "severity='".trim(addslashes($severity))."',".
         "source='".addslashes($_SERVER['SCRIPT_NAME'])."',".
@@ -85,7 +89,7 @@ function db_error($description, $severity = 'error')
 * Database command query
 *
 * Executes a SQL query
-* 
+*
 * @param string $sql
 *   SQL query to execute.
 * @param string &$error
@@ -98,12 +102,12 @@ function db_error($description, $severity = 'error')
 function db_db_command($sql, &$error)
 {
     global $db;
-    
+
     if (!$res = $db->query($sql)) {
         $error = $res->error . " (SQL: {$sql})";
         return false;
     }
-    
+
     return true;
 }
 
@@ -111,22 +115,22 @@ function db_db_command($sql, &$error)
 * Get the number of affected rows from the last query
 *
 * ...
-* 
+*
 * @return int
 *   The number of affected rows.
 */
 
 function db_db_affected_rows()
 {
-	global $db;
-	return $db->affected_rows;
+    global $db;
+    return $db->affected_rows;
 }
 
 /**
 * Database query
 *
 * Executes a SQL query and passes back the results.
-* 
+*
 * @param string $sql
 *   SQL query to execute.
 * @param array &$results
@@ -141,17 +145,17 @@ function db_db_affected_rows()
 function db_db_query($sql, &$results, &$error)
 {
     global $db;
-    
+
     if (!$res = $db->query($sql)) {
         $error = $res->error . " (SQL: {$sql})";
         return false;
     }
-    
+
     $results = array();
     while ($row = $res->fetch_assoc()) {
         $results[] = $row;
     }
-    
+
     return true;
 }
 
@@ -159,7 +163,7 @@ function db_db_query($sql, &$results, &$error)
 * Database query for one row
 *
 * Executes a SQL query and passes back the results.
-* 
+*
 * @param string $sql
 *   SQL query to execute.
 * @param array &$results
@@ -174,12 +178,12 @@ function db_db_query($sql, &$results, &$error)
 function db_db_getrow($sql, &$results, &$error)
 {
     global $db;
-    
+
     if (!db_db_query($sql, $results, $error)) {
         return false;
     }
 
-    $results = $results[0];
+    $results = (isset($results[0]) ? $results[0] : null);
     return true;
 }
 
@@ -187,7 +191,7 @@ function db_db_getrow($sql, &$results, &$error)
 * Database query for one column
 *
 * Executes a SQL query and passes back the results.
-* 
+*
 * @param string $sql
 *   SQL query to execute.
 * @param array &$results
@@ -202,17 +206,17 @@ function db_db_getrow($sql, &$results, &$error)
 function db_db_getcol($sql, &$results, &$error)
 {
     global $db;
-    
+
     if (!$res = $db->query($sql)) {
         $error = $res->error . " (SQL: {$sql})";
         return false;
     }
-    
+
     $results = array();
     while ($row = $res->fetch_row()) {
         $results[] = $row[0];
     }
-    
+
     return true;
 }
 
@@ -220,7 +224,7 @@ function db_db_getcol($sql, &$results, &$error)
 * Database query for one value
 *
 * Executes a SQL query and passes back the results.
-* 
+*
 * @param string $sql
 *   SQL query to execute.
 * @param string &$results
@@ -235,12 +239,12 @@ function db_db_getcol($sql, &$results, &$error)
 function db_db_getone($sql, &$results, &$error)
 {
     global $db;
-    
+
     if (!$res = $db->query($sql)) {
         $error = $res->error . " (SQL: {$sql})";
         return false;
     }
-    
+
     $row = $res->fetch_row();
     $results = $row[0];
 
@@ -251,7 +255,7 @@ function db_db_getone($sql, &$results, &$error)
 * Database query that returns an associative array
 *
 * Executes a SQL query and passes back the results.
-* 
+*
 * @param string $sql
 *   SQL query to execute.
 * @param array &$results
@@ -267,12 +271,12 @@ function db_db_getone($sql, &$results, &$error)
 function db_db_getassoc($sql, &$results, &$error)
 {
     global $db;
-    
+
     if (!$res = $db->query($sql)) {
         $error = $res->error . " (SQL: {$sql})";
         return false;
     }
-    
+
     $results = $res->fetch_assoc();
     return true;
 }
@@ -281,14 +285,14 @@ function db_db_getassoc($sql, &$results, &$error)
 * Prints an variable wrapped in <pre> tags.
 *
 * Uses the print_r function to display all the data in the variable.
-* 
+*
 * @param mixed $data
 *   Variable to print.
 */
 
 function db_print($data)
 {
-	echo "<pre>";
-	print_r($data);
-	echo "</pre>";
+    echo "<pre>";
+    print_r($data);
+    echo "</pre>";
 }

--- a/log.php
+++ b/log.php
@@ -4,8 +4,8 @@
 * Communications log
 *
 * Show the latest calls and texts.
-* 
-* 
+*
+*
 */
 
 require_once 'config.php';
@@ -24,26 +24,36 @@ $page = 50;
 
 // Mark an item as responded, or not responded
 if ($mark) {
-	sms_markCommunication($mark, true /* mark responded */, $error);
-} else if ($unmark) {
-	sms_markCommunication($unmark, false /* mark not responded */, $error);
+    sms_markCommunication($mark, true /* mark responded */, $error);
+} elseif ($unmark) {
+    sms_markCommunication($unmark, false /* mark not responded */, $error);
 }
 
 // Communications
 $sql = "SELECT communications.*,contacts_from.contact_name AS from_contact, contacts_to.contact_name AS to_contact ".
-	"FROM communications ".
-	"LEFT JOIN contacts AS contacts_from ON contacts_from.phone = communications.phone_from ".
-	"LEFT JOIN contacts AS contacts_to ON contacts_to.phone = communications.phone_to ".
-	($ph ? ("WHERE communications.phone_from = '".addslashes($ph)."' OR ".
-		    "      communications.phone_to = '".addslashes($ph)."' ") : '') .
-	"ORDER BY communication_time DESC LIMIT ".addslashes($start).",{$page}";
+    "FROM communications ".
+    "LEFT JOIN contacts AS contacts_from ON contacts_from.phone = communications.phone_from ".
+    "LEFT JOIN contacts AS contacts_to ON contacts_to.phone = communications.phone_to ".
+    ($ph ? ("WHERE communications.phone_from = '".addslashes($ph)."' OR ".
+            "      communications.phone_to = '".addslashes($ph)."' ") : '') .
+    "ORDER BY communication_time DESC LIMIT ".addslashes($start).",{$page}";
 if (!db_db_query($sql, $comms, $error)) {
-?><div class="alert alert-danger" role="alert"><?php echo $error ?></div><?php
+    ?><div class="alert alert-danger" role="alert"><?php echo $error ?></div><?php
 }
 
 ?>
-          <h2 class="sub-header">Log</h2>
-          <p>Click a phone number to view all communications with that number.  Click the response button or link to mark or 
+        <h2 class="sub-header">Hotline</h2>
+          <ul class="nav nav-pills">
+            <li role="presentation"><a href="hotline_active_calls.php">Active Calls</a></li>
+            <li role="presentation"><a href="hotline_staff.php">Staff</a></li>
+            <li role="presentation"><a href="hotline_blocks.php">Blocks</a></li>
+            <li role="presentation"><a href="hotline_languages.php">Languages</a></li>
+            <li role="presentation" class="active"><a href="log.php?ph=<?php echo sms_getFirstHotline($hotline_number, $hotline, $error) ? urlencode($hotline_number) : '' ?>">Log</a></li>
+          </ul>
+          <br />
+
+          <h3 class="sub-header">Log</h3>
+          <p>Click a phone number to view all communications with that number.  Click the response button or link to mark or
           unmark an item as responded to.</p>
           <form id="choose_number" action="log.php" method="GET" class="form-inline">
 		    <input type="hidden" name="s" value="<?php echo $start ?>">
@@ -52,18 +62,22 @@ if (!db_db_query($sql, $comms, $error)) {
 			<select class="form-control" name="ph" onChange="this.form.submit()">
 			 <option value="">(all numbers)</option>
 <?php
-	foreach ($HOTLINES as $hotline_number => $hotline) {
-?>
-			 <option value="<?php echo $hotline_number ?>" 
-				<?php if ($ph == $hotline_number) { echo "selected"; } ?>><?php echo $hotline_number ?> (<?php echo $hotline['name'] ?>)</option>
+    foreach ($HOTLINES as $hotline_number => $hotline) {
+        ?>
+			 <option value="<?php echo $hotline_number ?>"
+				<?php if ($ph == $hotline_number) {
+            echo "selected";
+        } ?>><?php echo $hotline_number ?> (<?php echo $hotline['name'] ?>)</option>
 <?php
-	}
-	if (isset($BROADCAST_CALLER_ID) && $BROADCAST_CALLER_ID) {
-?>
-			 <option value="<?php echo $BROADCAST_CALLER_ID ?>" 
-				<?php if ($ph == $BROADCAST_CALLER_ID) { echo "selected"; } ?>><?php echo $BROADCAST_CALLER_ID ?> (Broadcast)</option>
+    }
+    if (isset($BROADCAST_CALLER_ID) && $BROADCAST_CALLER_ID) {
+        ?>
+			 <option value="<?php echo $BROADCAST_CALLER_ID ?>"
+				<?php if ($ph == $BROADCAST_CALLER_ID) {
+            echo "selected";
+        } ?>><?php echo $BROADCAST_CALLER_ID ?> (Broadcast)</option>
 <?php
-	}
+    }
 ?>
 			</select>
  		   </div>
@@ -77,13 +91,13 @@ include 'communications.php';
 <?php
 // show the previous button if we are not at the beginning
 if ($start > 0) {
-?>
+    ?>
  <a class="btn btn-success" href="log.php?s=<?php echo $start - $page ?>" role="button">&lt;&lt; Prev</a>
 <?php
 }
 // show the next button if there are more to show
 if (count($comms) >= $page) {
-?>
+    ?>
  <a class="btn btn-success" href="log.php?s=<?php echo $start + $page ?>" role="button">Next &gt;&gt;</a>
 <?php
 }


### PR DESCRIPTION
Made several improvements to the "call times" section of the "staff"
page:

(1) Changed existing display of call times by breaking the various
    fields into multiple columns, one per field, for readability
    purposes.
(2) Changed existing display of call times to only display a given
    value if it is different from the previous row's value in the
    same column, or they are the same, but a value for this row to
    the left of this one was found to be different from the value
    in that column in the row above.
(3) Also made display of "receive call alerts"-only entries in the
    call times be dark red, to visually differentiate it from other
    entries for the user.
(4) Added a drop-down selector on the staff page allowing the choice
    of showing the call times sorted by user name (the old way), or
    sorted by day.
(5) Added an edit icon for all call times that reuses the existing
    "add call time" modal dialog to allow the user to edit an
    existing call time.
(6) Changed the modal dialog to use checkboxes for all the language
    choices, so that when a new call time is added, an entry is made
    in the call_times table for each language the user chose.
(7) Broke the add/edit call time modal dialog out into a new file,
    and separated functionality for the different ways of displaying
    call times into their own files as well. Also created a utility
    function file to hold common functions.
(8) Fixed a few PHP Notice log messages saying that variables were
    undefined in order to declutter the logs.