### PR TITLE
Use staff call time entries chronological boundaries appropriately

### DIFF
--- a/lib/lib_sms.php
+++ b/lib/lib_sms.php
@@ -54,8 +54,8 @@ function sms_getActiveContacts(&$contacts, $language_id, $receives, &$error)
         "((day='all' OR day='{$day}' OR ".
         ($weekend ? "day='weekends'" : "day='weekdays'") .
         ") AND ".
-        "((earliest < CURTIME() AND latest > CURTIME()) OR ".
-        " (earliest > latest AND (earliest < CURTIME() OR latest > CURTIME()))))";
+        "((earliest < CURTIME() AND ADDTIME(latest, '0:01:00') > CURTIME()) OR ".
+        " (earliest > latest AND (earliest < CURTIME() OR ADDTIME(latest, '0:01:00') > CURTIME()))))";
     if (!db_db_query($sql, $contacts, $error)) {
         return false;
     }


### PR DESCRIPTION
Ensure that staff call times' end times are inclusive of the entire minute, so that for example if a staff member's call time has an end time of 11:59am, that staff member will receive calls right up until 11:59:59.9999...am, but will of course not receive calls from 12:00:00pm on.