### PR TITLE
Prune duplicate call times, disallow future duplicates, adding/editing/removing now symmetric.

### DIFF
--- a/database_schema.sql
+++ b/database_schema.sql
@@ -63,6 +63,7 @@ CREATE TABLE `broadcast_tags` (
 
 CREATE TABLE `call_times` (
   `id` int(11) UNSIGNED NOT NULL,
+  `entry_id` int(11) UNSIGNED NOT NULL DEFAULT '0',
   `contact_id` int(11) UNSIGNED NOT NULL DEFAULT '0',
   `day` enum('all','weekdays','weekends','Sun','Mon','Tue','Wed','Thu','Fri','Sat') NOT NULL,
   `earliest` time NOT NULL,
@@ -175,12 +176,13 @@ ALTER TABLE `broadcast_tags`
   ADD PRIMARY KEY (`id`),
   ADD UNIQUE KEY `broadcast_id` (`broadcast_id`,`tag`),
   ADD KEY `broadcast_id_2` (`broadcast_id`,`tag`);
- 
+
 --
 -- Indexes for table `call_times`
 --
 ALTER TABLE `call_times`
   ADD PRIMARY KEY (`id`),
+  ADD KEY `entry_id` (`entry_id`),
   ADD KEY `contact_id` (`contact_id`),
   ADD KEY `language_id` (`language_id`);
 

--- a/database_update.php
+++ b/database_update.php
@@ -65,116 +65,127 @@ function unlockTablesForDatabaseUpdate($previousError)
     return true;
 }
 
-// Lock the table.
-if (!db_db_command("LOCK TABLES call_times WRITE", $error)) {
-    displayError("The call times table could not updated because it ".
-            "could not be locked in the database.");
-    return;
-}
+/**
+* Perform any database updates required to bring the database up to date.
+*/
+function ensureDatabaseIsUpToDate()
+{
 
-// Query the database for any duplicate sets of entries. Such a set is
-// a set of entries that share the same contact, day, earliest, latest,
-// received texts/calls/call answered alerts, languages, and enabled
-// values.
-$query = "SELECT GROUP_CONCAT(id) AS ids, contact_id, day, earliest, latest, ".
-        "receive_texts, receive_calls, receive_call_answered_alerts, ".
-        "language_id, enabled, count(*) FROM call_times GROUP BY ".
-        "contact_id, day, earliest, latest, receive_texts, receive_calls, ".
-        "receive_call_answered_alerts, language_id, enabled ".
-        "HAVING count(*) > 1";
-if (!db_db_query($query, $duplicateResults, $error)) {
-    unlockTablesForDatabaseUpdate("The call times table could not be checked ".
-            "for duplicate entries because a database error occurred: ".$error);
-    return;
-}
-
-// If any duplicate entries are found, iterate through the sets of
-// their identifiers, compiling a list of all such identifiers in each
-// set besides the first one, and then delete all the entries associated
-// with the compiled identifiers.
-if (!empty($duplicateResults)) {
-    $duplicateIds = array();
-    foreach ($duplicateResults as $duplicateResult) {
-        $ids = explode(",", $duplicateResult["ids"]);
-        array_shift($ids);
-        $duplicateIds = array_merge($duplicateIds, $ids);
-    }
-    $sql = "DELETE FROM call_times WHERE id IN (".implode(",", $duplicateIds).")";
-    if (!db_db_command($sql, $error)) {
-        unlockTablesForDatabaseUpdate("The call times table could not have ".
-                "duplicate entries pruned because a database error occurred: ".
-                $error);
-        return;
-    }
-    $numDuplicates = count($duplicateIds);
-    if ($numDuplicates == 1) {
-        displaySuccess("The call times table had a single duplicate entry ".
-                "pruned.");
-    } else {
-        displaySuccess("The call times table had ".$numDuplicates." duplicate ".
-                "entries pruned.");
-    }
-}
-
-// Determine whether or not the entry_id column exists in the table, and
-// if it does not, create it and populate it.
-$query = "SHOW COLUMNS FROM call_times LIKE 'entry_id'";
-if (!db_db_getone($query, $results, $error)) {
-    unlockTablesForDatabaseUpdate("The call times table could not be checked ".
-            "for the entry_id column's existence because a database error ".
-            "occurred: ".$error);
-    return;
-}
-if (!$results) {
-
-    // Add the column to the table.
-    $sql = "ALTER TABLE call_times ADD entry_id int(11) UNSIGNED NOT NULL ".
-            "DEFAULT '0' AFTER id";
-    if (!db_db_command($sql, $error)) {
-        unlockTablesForDatabaseUpdate("The call times table could not have ".
-                "the entry_id column added because a database error occurred: ".
-                $error);
+    // Lock the table.
+    if (!db_db_command("LOCK TABLES call_times WRITE", $error)) {
+        displayError("The call times table could not updated because it ".
+                "could not be locked in the database.");
         return;
     }
 
-    // Find all the entries, grouped so that all entries that need the
-    // same entry identifier are together.
+    // Query the database for any duplicate sets of entries. Such a set is
+    // a set of entries that share the same contact, day, earliest, latest,
+    // received texts/calls/call answered alerts, languages, and enabled
+    // values.
     $query = "SELECT GROUP_CONCAT(id) AS ids, contact_id, day, earliest, latest, ".
             "receive_texts, receive_calls, receive_call_answered_alerts, ".
-            "enabled, count(*) FROM call_times GROUP BY contact_id, day, ".
-            "earliest, latest, receive_texts, receive_calls, ".
-            "receive_call_answered_alerts, enabled";
-    if (!db_db_query($query, $entryResults, $error)) {
-        unlockTablesForDatabaseUpdate("The call times table could not have ".
-                "the new entry identifier column populated because a ".
-                "database error occurred: ".$error);
+            "language_id, enabled, count(*) FROM call_times GROUP BY ".
+            "contact_id, day, earliest, latest, receive_texts, receive_calls, ".
+            "receive_call_answered_alerts, language_id, enabled ".
+            "HAVING count(*) > 1";
+    if (!db_db_query($query, $duplicateResults, $error)) {
+        unlockTablesForDatabaseUpdate("The call times table could not be checked ".
+                "for duplicate entries because a database error occurred: ".$error);
         return;
     }
 
-    // Iterate through the results, setting each group of records to use
-    // a common entry identifier.
-    if (!empty($entryResults)) {
-        $entryIdentifier = 1;
-        foreach ($entryResults as $entryResult) {
-            $sql = "UPDATE call_times SET entry_id = ".$entryIdentifier.
-                    " WHERE id IN (".$entryResult["ids"].")";
-            if (!db_db_command($sql, $error)) {
-                unlockTablesForDatabaseUpdate("The call times table could not ".
-                        "have the new entry identifier column populated ".
-                        "because a database error occurred: ".$error);
-                return;
-            }
-            $entryIdentifier++;
+    // If any duplicate entries are found, iterate through the sets of
+    // their identifiers, compiling a list of all such identifiers in each
+    // set besides the first one, and then delete all the entries associated
+    // with the compiled identifiers.
+    if (!empty($duplicateResults)) {
+        $duplicateIds = array();
+        foreach ($duplicateResults as $duplicateResult) {
+            $ids = explode(",", $duplicateResult["ids"]);
+            array_shift($ids);
+            $duplicateIds = array_merge($duplicateIds, $ids);
+        }
+        $sql = "DELETE FROM call_times WHERE id IN (".implode(",", $duplicateIds).")";
+        if (!db_db_command($sql, $error)) {
+            unlockTablesForDatabaseUpdate("The call times table could not have ".
+                    "duplicate entries pruned because a database error occurred: ".
+                    $error);
+            return;
+        }
+        $numDuplicates = count($duplicateIds);
+        if ($numDuplicates == 1) {
+            displaySuccess("The call times table had a single duplicate entry ".
+                    "pruned.");
+        } else {
+            displaySuccess("The call times table had ".$numDuplicates." duplicate ".
+                    "entries pruned.");
         }
     }
 
-    displaySuccess("The call times table had the entry identifier column ".
-            "added and populated for all existing entries.");
+    // Determine whether or not the entry_id column exists in the table, and
+    // if it does not, create it and populate it.
+    $query = "SHOW COLUMNS FROM call_times LIKE 'entry_id'";
+    if (!db_db_getone($query, $results, $error)) {
+        unlockTablesForDatabaseUpdate("The call times table could not be checked ".
+                "for the entry_id column's existence because a database error ".
+                "occurred: ".$error);
+        return;
+    }
+    if (!$results) {
+
+        // Add the column to the table.
+        $sql = "ALTER TABLE call_times ADD entry_id int(11) UNSIGNED NOT NULL ".
+                "DEFAULT '0' AFTER id";
+        if (!db_db_command($sql, $error)) {
+            unlockTablesForDatabaseUpdate("The call times table could not have ".
+                    "the entry_id column added because a database error occurred: ".
+                    $error);
+            return;
+        }
+
+        // Find all the entries, grouped so that all entries that need the
+        // same entry identifier are together.
+        $query = "SELECT GROUP_CONCAT(id) AS ids, contact_id, day, earliest, latest, ".
+                "receive_texts, receive_calls, receive_call_answered_alerts, ".
+                "enabled, count(*) FROM call_times GROUP BY contact_id, day, ".
+                "earliest, latest, receive_texts, receive_calls, ".
+                "receive_call_answered_alerts, enabled";
+        if (!db_db_query($query, $entryResults, $error)) {
+            unlockTablesForDatabaseUpdate("The call times table could not have ".
+                    "the new entry identifier column populated because a ".
+                    "database error occurred: ".$error);
+            return;
+        }
+
+        // Iterate through the results, setting each group of records to use
+        // a common entry identifier.
+        if (!empty($entryResults)) {
+            $entryIdentifier = 1;
+            foreach ($entryResults as $entryResult) {
+                $sql = "UPDATE call_times SET entry_id = ".$entryIdentifier.
+                        " WHERE id IN (".$entryResult["ids"].")";
+                if (!db_db_command($sql, $error)) {
+                    unlockTablesForDatabaseUpdate("The call times table could not ".
+                            "have the new entry identifier column populated ".
+                            "because a database error occurred: ".$error);
+                    return;
+                }
+                $entryIdentifier++;
+            }
+        }
+
+        displaySuccess("The call times table had the entry identifier column ".
+                "added and populated for all existing entries.");
+    }
+
+    // Unlock the table.
+    if (!unlockTablesForDatabaseUpdate(null)) {
+        return;
+    }
+
+    displaySuccess("Update completed successfully.");
 }
 
-// Unlock the table.
-if (!unlockTablesForDatabaseUpdate(null)) {
-    return;
-}
+ensureDatabaseIsUpToDate();
 
-displaySuccess("Update completed successfully.");
+include 'footer.php';

--- a/database_update.php
+++ b/database_update.php
@@ -1,0 +1,180 @@
+<?php
+/**
+* @file
+* Database update file. This should be updated as the application
+* evolved to know how to perform updates on an existing database to
+* bring it up to current spec.
+*
+* For example, if a new column is added to a table, this file's
+* algorithm should look for the new column in the table, and if not
+* found, should add it and do whatever is necessary to properly
+* populate it. The idea is to ensure that it never corrupts an
+* existing already up-to-date database, of course.
+*/
+
+
+require_once 'config.php';
+
+include 'header.php';
+
+/**
+* Display the specified error message.
+*
+* @param string $error
+*   Error message to be displayed.
+*/
+function displayError($error)
+{
+    echo "<div class=\"alert alert-danger\" role=\"alert\">".$error."</div>";
+}
+
+/**
+* Display the specified success message.
+*
+* @param string $message
+*   Success message to be displayed.
+*/
+function displaySuccess($message)
+{
+    echo "<div class=\"alert alert-success\" role=\"alert\">".$message."</div>";
+}
+
+/**
+* Unlock any locked tables, displaying the specified error message if any.
+*
+* @param string $previousError
+*   Error message to be displayed if the unlock succeeds, or to be displayed
+*   along with the unlock error message if the unlock fails.
+* @return bool
+*   True if the table was unlocked, false otherwise.
+*/
+function unlockTablesForDatabaseUpdate($previousError)
+{
+    if (!db_db_command("UNLOCK TABLES", $error)) {
+        if (empty($previousError)) {
+            displayError("The call times table update could not be completed ".
+                    "because it could not be unlocked in the database.");
+        } else {
+            displayError($previousError."<br><br>Additionally, The call times ".
+                    "table could not be unlocked in the database.");
+        }
+        return false;
+    } elseif (!empty($previousError)) {
+        displayError($previousError);
+    }
+    return true;
+}
+
+// Lock the table.
+if (!db_db_command("LOCK TABLES call_times WRITE", $error)) {
+    displayError("The call times table could not updated because it ".
+            "could not be locked in the database.");
+    return;
+}
+
+// Query the database for any duplicate sets of entries. Such a set is
+// a set of entries that share the same contact, day, earliest, latest,
+// received texts/calls/call answered alerts, languages, and enabled
+// values.
+$query = "SELECT GROUP_CONCAT(id) AS ids, contact_id, day, earliest, latest, ".
+        "receive_texts, receive_calls, receive_call_answered_alerts, ".
+        "language_id, enabled, count(*) FROM call_times GROUP BY ".
+        "contact_id, day, earliest, latest, receive_texts, receive_calls, ".
+        "receive_call_answered_alerts, language_id, enabled ".
+        "HAVING count(*) > 1";
+if (!db_db_query($query, $duplicateResults, $error)) {
+    unlockTablesForDatabaseUpdate("The call times table could not be checked ".
+            "for duplicate entries because a database error occurred: ".$error);
+    return;
+}
+
+// If any duplicate entries are found, iterate through the sets of
+// their identifiers, compiling a list of all such identifiers in each
+// set besides the first one, and then delete all the entries associated
+// with the compiled identifiers.
+if (!empty($duplicateResults)) {
+    $duplicateIds = array();
+    foreach ($duplicateResults as $duplicateResult) {
+        $ids = explode(",", $duplicateResult["ids"]);
+        array_shift($ids);
+        $duplicateIds = array_merge($duplicateIds, $ids);
+    }
+    $sql = "DELETE FROM call_times WHERE id IN (".implode(",", $duplicateIds).")";
+    if (!db_db_command($sql, $error)) {
+        unlockTablesForDatabaseUpdate("The call times table could not have ".
+                "duplicate entries pruned because a database error occurred: ".
+                $error);
+        return;
+    }
+    $numDuplicates = count($duplicateIds);
+    if ($numDuplicates == 1) {
+        displaySuccess("The call times table had a single duplicate entry ".
+                "pruned.");
+    } else {
+        displaySuccess("The call times table had ".$numDuplicates." duplicate ".
+                "entries pruned.");
+    }
+}
+
+// Determine whether or not the entry_id column exists in the table, and
+// if it does not, create it and populate it.
+$query = "SHOW COLUMNS FROM call_times LIKE 'entry_id'";
+if (!db_db_getone($query, $results, $error)) {
+    unlockTablesForDatabaseUpdate("The call times table could not be checked ".
+            "for the entry_id column's existence because a database error ".
+            "occurred: ".$error);
+    return;
+}
+if (!$results) {
+
+    // Add the column to the table.
+    $sql = "ALTER TABLE call_times ADD entry_id int(11) UNSIGNED NOT NULL ".
+            "DEFAULT '0' AFTER id";
+    if (!db_db_command($sql, $error)) {
+        unlockTablesForDatabaseUpdate("The call times table could not have ".
+                "the entry_id column added because a database error occurred: ".
+                $error);
+        return;
+    }
+
+    // Find all the entries, grouped so that all entries that need the
+    // same entry identifier are together.
+    $query = "SELECT GROUP_CONCAT(id) AS ids, contact_id, day, earliest, latest, ".
+            "receive_texts, receive_calls, receive_call_answered_alerts, ".
+            "enabled, count(*) FROM call_times GROUP BY contact_id, day, ".
+            "earliest, latest, receive_texts, receive_calls, ".
+            "receive_call_answered_alerts, enabled";
+    if (!db_db_query($query, $entryResults, $error)) {
+        unlockTablesForDatabaseUpdate("The call times table could not have ".
+                "the new entry identifier column populated because a ".
+                "database error occurred: ".$error);
+        return;
+    }
+
+    // Iterate through the results, setting each group of records to use
+    // a common entry identifier.
+    if (!empty($entryResults)) {
+        $entryIdentifier = 1;
+        foreach ($entryResults as $entryResult) {
+            $sql = "UPDATE call_times SET entry_id = ".$entryIdentifier.
+                    " WHERE id IN (".$entryResult["ids"].")";
+            if (!db_db_command($sql, $error)) {
+                unlockTablesForDatabaseUpdate("The call times table could not ".
+                        "have the new entry identifier column populated ".
+                        "because a database error occurred: ".$error);
+                return;
+            }
+            $entryIdentifier++;
+        }
+    }
+
+    displaySuccess("The call times table had the entry identifier column ".
+            "added and populated for all existing entries.");
+}
+
+// Unlock the table.
+if (!unlockTablesForDatabaseUpdate(null)) {
+    return;
+}
+
+displaySuccess("Update completed successfully.");

--- a/hotline_call_times_alpha.php
+++ b/hotline_call_times_alpha.php
@@ -167,11 +167,11 @@ foreach ($contacts as $contact) {
                 title="Add a call time for this staff member">
             <span class="glyphicon glyphicon-plus" aria-hidden="true"></span></a>
           <a href="hotline_staff.php?display_type=alphabetical&action=editcalltimemodal&id=<?php
-                echo $call_time['id'] ?>"
+                echo $call_time['entry_id'] ?>"
                 title="Edit this call time">
             <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></a>
           <a href="hotline_staff.php?display_type=alphabetical&action=removecalltime&id=<?php
-                echo $call_time['id'] ?>"
+                echo $call_time['entry_id'] ?>"
                 onClick="return confirm('Are you sure you want to remove this call time?');"
                 title="Remove this call time">
             <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>

--- a/hotline_call_times_chrono.php
+++ b/hotline_call_times_chrono.php
@@ -215,11 +215,11 @@ if ($TEST_MODE) {
                     title="Add a call time for this staff member">
                   <span class="glyphicon glyphicon-plus" aria-hidden="true"></span></a>
               <a href="hotline_staff.php?display_type=chronological&action=editcalltimemodal&id=<?php
-                    echo $call_time['id'] ?>"
+                    echo $call_time['entry_id'] ?>"
                     title="Edit this call time">
                   <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></a>
               <a href="hotline_staff.php?display_type=chronological&action=removecalltime&id=<?php
-                    echo $call_time['id'] ?>"
+                    echo $call_time['entry_id'] ?>"
                   onClick="return confirm('<?php echo $confirmation_message; ?>');"
                   title="Remove this call time">
                <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
@@ -253,6 +253,7 @@ function getResultsUsingHybridQuery()
         $query =
             "SELECT DISTINCT ".
                 "call_times.id, ".
+                "call_times.entry_id, ".
                 "call_times.day AS original_day, ".
                 "call_times.day + 0 AS original_day_ordinal, ".
                 "call_times.earliest AS earliest_time, ".
@@ -282,6 +283,7 @@ function getResultsUsingHybridQuery()
     $query =
         "SELECT DISTINCT ".
             "call_times.id, ".
+            "call_times.entry_id, ".
             "call_times.day AS original_day, ".
             "call_times.day + 0 AS original_day_ordinal, ".
             "call_times.day AS day_of_week, ".
@@ -332,8 +334,8 @@ function getResultsUsingHybridQuery()
         foreach ($multiDayResults[$grouping] as $multiDayResult) {
             foreach ($days as $day => $ordinal) {
 
-                // Copy he multi-day result, then insert into it
-                // valuesfor the 'day_of_week' and 'day_ordinal'
+                // Copy the multi-day result, then insert into it
+                // values for the 'day_of_week' and 'day_ordinal'
                 // indices. Then add it to the list of single-day
                 // results.
                 $result = $multiDayResult;
@@ -376,6 +378,7 @@ function getResultsUsingPureSqlQuery()
         $query .=
             "(SELECT DISTINCT ".
                 "call_times.id, ".
+                "call_times.entry_id, ".
                 "call_times.day AS original_day, ".
                 "call_times.day + 0 AS original_day_ordinal, ".
                 "'". $day. "' AS day_of_week, ".

--- a/lib/lib_db.php
+++ b/lib/lib_db.php
@@ -104,7 +104,7 @@ function db_db_command($sql, &$error)
     global $db;
 
     if (!$res = $db->query($sql)) {
-        $error = $res->error . " (SQL: {$sql})";
+        $error = $db->error . " (SQL: {$sql})";
         return false;
     }
 
@@ -147,7 +147,7 @@ function db_db_query($sql, &$results, &$error)
     global $db;
 
     if (!$res = $db->query($sql)) {
-        $error = $res->error . " (SQL: {$sql})";
+        $error = $db->error . " (SQL: {$sql})";
         return false;
     }
 
@@ -208,7 +208,7 @@ function db_db_getcol($sql, &$results, &$error)
     global $db;
 
     if (!$res = $db->query($sql)) {
-        $error = $res->error . " (SQL: {$sql})";
+        $error = $db->error . " (SQL: {$sql})";
         return false;
     }
 
@@ -241,7 +241,7 @@ function db_db_getone($sql, &$results, &$error)
     global $db;
 
     if (!$res = $db->query($sql)) {
-        $error = $res->error . " (SQL: {$sql})";
+        $error = $db->error . " (SQL: {$sql})";
         return false;
     }
 
@@ -273,7 +273,7 @@ function db_db_getassoc($sql, &$results, &$error)
     global $db;
 
     if (!$res = $db->query($sql)) {
-        $error = $res->error . " (SQL: {$sql})";
+        $error = $db->error . " (SQL: {$sql})";
         return false;
     }
 


### PR DESCRIPTION
Made a some improvements to the "call times" section of the "staff" page, and to the database table used to manage call times.

**IMPORTANT**: The database_update.php script **_must_** be run on existing databases prior to attempting to navigate the hotline_staff.php ("call times") page or any associated page (i.e. viewing, adding, editing, or deleting staff records or call times). Failure to do so will result in database errors.

(1) Added a new page, database_update.php, which when loaded, ensures that the database does not have any duplicate entries. "Duplicate" is defined at this time as having the same value for every field, including the "enabled" field. Existing duplicate entries are pruned so that only one remains of each such group.

The page then ensures that the column "entry_id" is present in the call_times table, and if it is not, adds it and populates it. The new column is used to allow multiple entries that are identical except for the language_id to share the same entry identifier, so that they may be edited and deleted together.

(2) Added checks to the add-staff, add-time, and edit-time algorithms to ensure the user is not attempting to add a dupllicate entry (in the first two cases), or modify an existing entry so that it effectively becomes a duplicate of another existing entry (in the last case).

(3) Added code to the same three algorithms as in (2) that uses the new "entry_id" column, so that added call time entries sharing all but language share the same entry identifier, and thus the editing of an entry allows the all associated records to be modified at once. So, if the user attempts to edit an entry that has both English and Spanish associated with it (meaning two rows in the database), the Edit dialog allows the languages associated with the entry to be changed, and updates that database accordingly if the user goes through with the edit. Also changed the remove-time algorithm to remove all records associated with an entry.

(4) Modified the DB library functions to properly output error strings when a problem occurs.

The net result from an end-user perspective is that call time entries that are duplicates of existing entries cannot be created (or updated to create such duplicates); and that editing of call time entries with the modal dialog is now similar to creating them with the same dialog, in that the languages associated with an entry may be edited.