### PR TITLE
Multiple broadcast numbers; Twilio Notify support; broadcast countdown timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ It is not production ready and is very much in progress.
 * Copy the "config_sample.php" file to "config.php".  Edit the "config.php" file:
   * The $TWILIO_ACCOUNT_SID and $TWILIO_AUTH_TOKEN can be found from the [Twilio Account Dashboard] (https://www.twilio.com/user/account).
   * Put the database credentials in the $HOTLINE_DB_ settings.
-  * For mass texting, set the $BROADCAST_ settings including the phone number to use in the '+1NXXNXXXXXX' format ($BROADCAST_CALLER_ID).
+  * For mass texting, set the $BROADCAST_ settings including the phone numbers to use in the '+1NXXNXXXXXX' format ($BROADCAST_CALLER_IDS).
   * For hotlines, set the $HOTLINE_ and $HOTLINES settings including the phone numbers to use in the '+1NXXNXXXXXX' format.
 
 * In your Twilio account, configure each number to make a webhook request to the application.  Use the HTTP basic security you set above (replace username and password and the web address below as appropriate).  For voice, use:
@@ -52,10 +52,26 @@ It is not production ready and is very much in progress.
   
    https://username:password@(web address, example: hotline.hotline.org)/twin/incoming-sms.php
 
-* Optional.  To enable in-browser outbound calling, create a TwiML app (under Phone numbers, Tools) with a voice request URL of:
+* Optional.  To enable in-browser outbound calling, in your Twilio account create a TwiML app (under Phone numbers, Tools) with a voice request URL of:
 
    https://username:password@(web address, example: hotline.hotline.org)/call/voice.php
   * Once you've created the TwiML app, copy its SID and set the $TWILIO_TWIML_APP_SID setting in config.php to it.
+
+* Optional.  To enable using Twilio's Notify service to broadcast text from multiple numbers at once:
+  * Create a Messenging Service in your Twilio account (under Programmable SMS, Messenging Services).
+    * Under the "Configure" menu item:
+      * Select the use case "Notifications, 2-Way".
+      * Check the "Process Inbound Messages" checkbox.
+      * Set the "Request URL" to:
+   https://username:password@(web address, example: hotline.hotline.org)/twin/incoming-sms.php
+      * Verify that "Sticky Sender" is enabled.
+    * Under the "Numbers" menu item:
+      * Add each of the numbers you would like to broadcast from.
+  * Create a Notify Service in your Twilio account (under Notify, Services).
+    * Under the "Configure" menu item:
+      * Select the messenging service you created above under the "Properties, Messenging Service SID"
+    * Copy the "Service SID" to the $BROADCAST_TWILIO_NOTIFY_SERVICE setting in config.php.
+  * Add each of the numbers you are broadcasting from to the $BROADCAST_CALLER_IDS array.
 
 * By default, English and Spanish are set - edit the "languages" table to modify this.  The Twilio code is the language that the voice "alice" will use to speak the text.
   * Each of the prompts may be either the text to be spoken, or a URL to play.  

--- a/broadcast.php
+++ b/broadcast.php
@@ -330,6 +330,21 @@ function sendBroadcastText($text, $request_response, $tags, &$error, &$message)
 		return false;
 	}
 
+    // calculate how many texts will be sent, divide it by the number
+	// of broadcast numbers, and store that in the MessageSid (twilio_sid)
+	// field, which is not otherwise used
+	$count_per_number = floor(strlen($text) / 160) + 1;
+	$seconds_total = ceil(($count_per_number * count($numbers)) / count($BROADCAST_CALLER_IDS));
+	
+	// store the text
+	$data = array(
+		'From' => reset($BROADCAST_CALLER_IDS),
+		'To' => ($request_response ? 'BROADCAST_RESPONSE' : 'BROADCAST'),
+		'Body' => $text . $tags_description,
+		'MessageSid' => 'text ' . $seconds_total
+	);
+	sms_storeCallData($data, $error);
+
 	// send via Twilio notify?
 	if ($BROADCAST_TWILIO_NOTIFY_SERVICE) {
 		// yes
@@ -344,21 +359,6 @@ function sendBroadcastText($text, $request_response, $tags, &$error, &$message)
 		}
 	}
 	
-	// calculate how many texts were just sent, divide it by the number
-	// of broadcast numbers, and store that in the MessageSid (twilio_sid)
-	// field, which is not otherwise used
-	$count_per_number = floor(strlen($text) / 160) + 1;
-	$seconds_total = ceil(($count_per_number * count($numbers)) / count($BROADCAST_CALLER_IDS));
-	
-	// store the text
-	$data = array(
-		'From' => $broadcast_from,
-		'To' => ($request_response ? 'BROADCAST_RESPONSE' : 'BROADCAST'),
-		'Body' => $text . $tags_description,
-		'MessageSid' => 'text ' . $seconds_total
-	);
-	sms_storeCallData($data, $error);
-
 	$message = "Text sent to " . count($numbers) . " numbers" .
 		($error ? ' (except errors listed above).' : '.');
 	return true;
@@ -427,6 +427,21 @@ function sendBroadcastResponseText($text, $communications_id, &$error, &$message
 		return false;
 	}
 	
+	// calculate how many texts will be sent, divide it by the number
+	// of broadcast numbers, and store that in the MessageSid (twilio_sid)
+	// field, which is not otherwise used
+	$count_per_number = floor(strlen($text) / 160) + 1;
+	$seconds_total = ceil(($count_per_number * count($numbers)) / count($BROADCAST_CALLER_IDS));
+	
+	// store the text
+	$data = array(
+		'From' => reset($BROADCAST_CALLER_IDS),
+		'To' => 'BROADCAST_RESPONSE_UPDATE',
+		'Body' => $text,
+		'MessageSid' => 'text ' . $seconds_total
+	);
+	sms_storeCallData($data, $error);
+
 	// send via Twilio notify?
 	if ($BROADCAST_TWILIO_NOTIFY_SERVICE) {
 		// yes
@@ -441,21 +456,6 @@ function sendBroadcastResponseText($text, $communications_id, &$error, &$message
 		}
 	}
 	
-	// calculate how many texts were just sent, divide it by the number
-	// of broadcast numbers, and store that in the MessageSid (twilio_sid)
-	// field, which is not otherwise used
-	$count_per_number = floor(strlen($text) / 160) + 1;
-	$seconds_total = ceil(($count_per_number * count($numbers)) / count($BROADCAST_CALLER_IDS));
-	
-	// store the text
-	$data = array(
-		'From' => $broadcast_from,
-		'To' => 'BROADCAST_RESPONSE_UPDATE',
-		'Body' => $text,
-		'MessageSid' => 'text ' . $seconds_total
-	);
-	sms_storeCallData($data, $error);
-
 	$message = "Text sent to " . count($numbers) . " numbers.";
 	return true;
 }

--- a/broadcast_admin.php
+++ b/broadcast_admin.php
@@ -66,7 +66,7 @@ if ($success) {
 			<li role="presentation"><a href="broadcast.php">Send</a></li>
 			<li role="presentation"<?php if (substr($action, 0, 4) != 'list') echo ' class="active"'?>><a href="broadcast_admin.php">Import &amp; Remove</a></li>
 			<li role="presentation"<?php if (substr($action, 0, 4) == 'list') echo ' class="active"'?>><a href="broadcast_admin.php?action=list">List</a></li>
-			<li role="presentation"><a href="log.php?ph=<?php echo urlencode($BROADCAST_CALLER_ID) ?>">Log</a></li>
+			<li role="presentation"><a href="log.php?ph=all_broadcast">Log</a></li>
 		  </ul>
 <?php
 // display the import/remove information unless a list is requested

--- a/broadcast_admin.php
+++ b/broadcast_admin.php
@@ -60,6 +60,13 @@ if ($success) {
 <?php
 }
 
+// is a broadcast in progress?
+if (sms_isBroadcastInProgress($remaining, $error)) {
+?>
+	      <div class="alert alert-info" role="alert">Broadcasts in progress (approx. <b><?php echo $remaining ?></b> remaining)</div>
+<?php
+}
+
 ?>
 		  <h2 class="sub-header">Broadcast</h2>
 		  <ul class="nav nav-pills">
@@ -260,9 +267,6 @@ function importNumbers($numbers, $tags, &$error, &$message, $send_welcome = true
 	
 	// send the welcome messages if set
 	if ($send_welcome && $BROADCAST_WELCOME) {
-		// use the first caller id as the default
-		$broadcast_from = reset($BROADCAST_CALLER_IDS);
-
 		// use the Twilio Notify service?
 		if ($BROADCAST_TWILIO_NOTIFY_SERVICE) {
 			// yes
@@ -271,7 +275,7 @@ function importNumbers($numbers, $tags, &$error, &$message, $send_welcome = true
 		} else {
 			// no, send the texts one by one
 			sms_send($success_numbers, $BROADCAST_WELCOME, $send_error, 
-					 $broadcast_from, $BROADCAST_PROGRESS_MARK_EVERY);
+					 $BROADCAST_CALLER_IDS, $BROADCAST_PROGRESS_MARK_EVERY);
 			$error .= $send_error;
 		}
 	}

--- a/call/store.php
+++ b/call/store.php
@@ -16,7 +16,7 @@ db_databaseConnect();
 $from = $_REQUEST['From'];
 
 // ensure that the "from" number is hotline or broadcast.  Default to first hotline.
-if ($from != $BROADCAST_CALLER_ID && !array_key_exists($from, $HOTLINES)) {
+if (!in_array($from, $BROADCAST_CALLER_IDS) && !array_key_exists($from, $HOTLINES)) {
 	sms_getFirstHotline($from, $hotline, $error);
 }
 

--- a/call/voice.php
+++ b/call/voice.php
@@ -18,7 +18,7 @@ if (isset($_REQUEST['To']) && strlen($_REQUEST['To']) > 0) {
     $from = htmlspecialchars($_REQUEST['From']);
     
     // ensure that the "from" number is hotline or broadcast.  Default to first hotline.
-	if ($from != $BROADCAST_CALLER_ID && !array_key_exists($from, $HOTLINES)) {
+	if (!in_array($from, $BROADCAST_CALLER_IDS) && !array_key_exists($from, $HOTLINES)) {
 		sms_getFirstHotline($from, $hotline, $error);
 	}
     

--- a/communications_export.php
+++ b/communications_export.php
@@ -14,6 +14,7 @@
 
 ?>
 	      <h3>Export to CSV</h2>
+	      <p class="help-block">Use <b>all_broadcast</b> as the phone number to include all broadcast numbers.</p>
 		  <form class="form-inline" action="export.php" method="POST">
 			<div class="form-group">
 			  <label for="export_earliest">Earliest: </label>
@@ -30,8 +31,8 @@
 			<div class="form-group">
 			  <label for="export_phone">Limit to phone: </label>
 			  <input type="text" class="form-control" name="export[phone]" id="export_phone" 
-			         placeholder="<?php echo sms_getFirstHotline($hotline_number, $hotline, $error) ? $hotline_number : $BROADCAST_CALLER_ID ?>"
-			         value="<?php echo $export['phone'] ?>">
+			         placeholder="<?php echo sms_getFirstHotline($hotline_number, $hotline, $error) ? $hotline_number : reset($BROADCAST_CALLER_IDS) ?>"
+			         value="<?php echo $export['phone'] ?>">			  
 			</div>
 			<div class="form-group">
 			  <label for="export_type">Type: </label>

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "twilio/sdk": "^5.5"
+        "twilio/sdk": "^5.16"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ae95c9b7ea772b4420335e45f7fb26cc",
-    "content-hash": "03bd9da8d1665267ce78509a77ea2677",
+    "hash": "71d6c2decc920d4d725004b31ae9f3c0",
+    "content-hash": "9e3d6a1a2964dae6eefc0e9624bdf63c",
     "packages": [
         {
             "name": "twilio/sdk",
-            "version": "5.5.0",
+            "version": "5.16.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twilio/twilio-php.git",
-                "reference": "5914ee36b68825d859cc55ceb9d75fa2b3e22c13"
+                "reference": "24b6830fa3157cb7e11108ee74eb678e83147593"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twilio/twilio-php/zipball/5914ee36b68825d859cc55ceb9d75fa2b3e22c13",
-                "reference": "5914ee36b68825d859cc55ceb9d75fa2b3e22c13",
+                "url": "https://api.github.com/repos/twilio/twilio-php/zipball/24b6830fa3157cb7e11108ee74eb678e83147593",
+                "reference": "24b6830fa3157cb7e11108ee74eb678e83147593",
                 "shasum": ""
             },
             "require": {
@@ -51,7 +51,7 @@
                 "sms",
                 "twilio"
             ],
-            "time": "2017-02-08 01:09:48"
+            "time": "2017-12-16 01:07:41"
         }
     ],
     "packages-dev": [],

--- a/config_sample.php
+++ b/config_sample.php
@@ -36,7 +36,10 @@ $TWILIO_TWIML_APP_SID = '';
 // **** BROADCAST ****
 
 // Broadcast number
-$BROADCAST_CALLER_ID = '+1NXXNXXXXXX';
+$BROADCAST_CALLER_IDS = array('+1NXXNXXXXXX');
+
+// Optional Twilio Notify Service SID
+$BROADCAST_TWILIO_NOTIFY_SERVICE = '';
 
 // Broadcast prompts
 $BROADCAST_WELCOME = "Welcome to the ". $HOTLINE_NAME . " alert list. ".

--- a/config_sample.php
+++ b/config_sample.php
@@ -49,11 +49,19 @@ $BROADCAST_GOODBYE = "You will no longer receive ". $HOTLINE_NAME . " alerts.";
 
 // If set, callers will hear this message in each language and then it will hang up.  The format is an array, 
 // with each key the language code, and the value the text to read in that language.  "es-MX" is Spanish, 
-// "en-US" is English.
+// "en-US" is English.  Don't set this and $BROADCAST_SEND_TO_HOTLINE.
 // Example: 'en-US' => "Goodbye"
 $BROADCAST_VOICE_MESSAGES = array(
 
 );
+
+// If set, callers to the broadcast numbers will be redirected to this hotline.
+// Don't set this and $BROADCAST_VOICE_MESSAGES
+$BROADCAST_SEND_TO_HOTLINE = '';
+
+// When a broadcast text is sent that is limited to certain tags, this text will be added to the database 
+// records of the text.
+$BROADCAST_LIMITED_TO_TAGS_TEXT = "LIMITED TO TAGS";
 
 // List users authorized to send broadcast texts here.  Leave blank to allow all users.
 $BROADCAST_AUTHORIZED_USERS = array();

--- a/config_sample.php
+++ b/config_sample.php
@@ -42,10 +42,10 @@ $BROADCAST_CALLER_IDS = array('+1NXXNXXXXXX');
 $BROADCAST_TWILIO_NOTIFY_SERVICE = '';
 
 // Broadcast prompts
-$BROADCAST_WELCOME = "Welcome to the ". $HOTLINE_NAME . " alert list. ".
-	"To remove yourself from the list, text OFF. To put yourself back on, ".
+$BROADCAST_WELCOME = "Welcome to the alert list. ".
+	"To remove yourself from the list, text OFF.";
+$BROADCAST_GOODBYE = "You will no longer receive alerts. To put yourself back on, ".
 	"text ON.";
-$BROADCAST_GOODBYE = "You will no longer receive ". $HOTLINE_NAME . " alerts.";
 
 // If set, callers will hear this message in each language and then it will hang up.  The format is an array, 
 // with each key the language code, and the value the text to read in that language.  "es-MX" is Spanish, 

--- a/contact.php
+++ b/contact.php
@@ -25,7 +25,7 @@ if ($ph) {
 }
 
 // ensure that the "from" number is hotline or broadcast.  Default to first hotline.
-if ($from != $BROADCAST_CALLER_ID && !array_key_exists($from, $HOTLINES)) {
+if (!in_array($from, $BROADCAST_CALLER_IDS) && !array_key_exists($from, $HOTLINES)) {
 	sms_getFirstHotline($from, $hotline, $error);
 }
 
@@ -176,7 +176,7 @@ if (count($comms) >= $page) {
 		   <div class="form-group">
 			<label for="text-message">Phone number</label>
 			<input type="text" class="form-control" name="ph" 
-			       placeholder="<?php echo sms_getFirstHotline($hotline_number, $hotline, $error) ? $hotline_number : $BROADCAST_CALLER_ID ?>"
+			       placeholder="<?php echo sms_getFirstHotline($hotline_number, $hotline, $error) ? $hotline_number : reset($BROADCAST_CALLER_IDS) ?>"
 			       value="<?php echo $ph ?>">
  		   </div>		  
 		   <button class="btn btn-success" id="button-text">Lookup</button>
@@ -198,7 +198,7 @@ include 'footer.php';
 
 function displayPhoneOptions($selected)
 {
-	global $HOTLINES, $BROADCAST_CALLER_ID;
+	global $HOTLINES, $BROADCAST_CALLER_IDS;
 	
 	foreach ($HOTLINES as $hotline_number => $hotline) {
 ?>
@@ -206,11 +206,13 @@ function displayPhoneOptions($selected)
 				<?php if ($selected == $hotline_number) { echo "selected"; } ?>><?php echo $hotline_number ?> (<?php echo $hotline['name'] ?>)</option>
 <?php
 	}
-	if (isset($BROADCAST_CALLER_ID) && $BROADCAST_CALLER_ID) {
+	if (isset($BROADCAST_CALLER_IDS)) {
+		foreach ($BROADCAST_CALLER_IDS as $broadcast_caller_id) {
 ?>
-			 <option value="<?php echo $BROADCAST_CALLER_ID ?>" 
-				<?php if ($selected == $BROADCAST_CALLER_ID) { echo "selected"; } ?>><?php echo $BROADCAST_CALLER_ID ?> (Broadcast)</option>
+			 <option value="<?php echo $broadcast_caller_id ?>" 
+				<?php if ($selected == $broadcast_caller_id) { echo "selected"; } ?>><?php echo $broadcast_caller_id ?> (Broadcast)</option>
 <?php
+		}
 	}
 }
 

--- a/index.php
+++ b/index.php
@@ -47,12 +47,18 @@ if (!db_db_query($sql, $comms, $error)) {
           <h2 class="sub-header"><?php echo $WEBSITE_NAME ?></h2>
           <div class="container">
 		   <div class="row">
+<?php
+if (isset($BROADCAST_CALLER_IDS)) {
+?>
 			<div class="col-md-4">
 			  <h3>Broadcast texts</h3>
 			  <p>Administer the list and send texts to the <b><?php echo $broadcast_count ?></b> numbers in the database from the
-			  <b><?php echo $BROADCAST_CALLER_ID ?></b> number.</p>
+			  broadcast numbers: <b><?php echo implode(', ', $BROADCAST_CALLER_IDS) ?></b>.</p>
 			  <p><a class="btn btn-success" href="broadcast.php" role="button">Broadcast</a></p>
 			</div>
+<?php
+}
+?>			
 			<div class="col-md-4">
 			  <h3>Hotline 
 <?php

--- a/lib/lib_sms.php
+++ b/lib/lib_sms.php
@@ -148,6 +148,57 @@ function sms_send($numbers, $text, &$error, $from = '', $progress_every = 0)
 }
 
 /**
+* Send a text message to a list of numbers via Twilio's Notify service
+*
+* ...
+* 
+* @param array $numbers
+*   Array of phone numbers to send the text to.
+* @param string $text
+*   The body of the text message.
+* @param string &$error
+*   An error if one occurred.
+*   
+* @return bool
+*   True unless no messages were sent successfully.
+*/
+
+function sms_sendViaNotify($numbers, $text, &$error)
+{
+	global $TWILIO_ACCOUNT_SID, $TWILIO_AUTH_TOKEN, $BROADCAST_TWILIO_NOTIFY_SERVICE;
+	
+	if (!count($numbers)) {
+		// there are no messages to send
+		return true;
+	}
+
+	// create an array of bindings
+	$to_bindings = array();
+	foreach ($numbers as $number) {
+		$to_bindings[] = 
+			'{"binding_type":"sms", "address":"' . $number . '"}';
+	}
+
+	// create a Twilio client
+	$client = new Client($TWILIO_ACCOUNT_SID, $TWILIO_AUTH_TOKEN);
+
+	// send the messages
+    try {
+		$notification = $client
+			->notify->services($BROADCAST_TWILIO_NOTIFY_SERVICE)
+			->notifications->create([
+				"toBinding" => $to_bindings,
+				"body" => $text
+			]);
+	} catch (Exception $e) {
+		$error = $e->getMessage();
+		return false;
+	}
+        
+	return true;
+}
+
+/**
 * Place calls to a list of numbers
 *
 * ...

--- a/log.php
+++ b/log.php
@@ -57,17 +57,7 @@ if (!db_db_query($sql, $comms, $error)) {
 }
 
 ?>
-        <h2 class="sub-header">Hotline</h2>
-          <ul class="nav nav-pills">
-            <li role="presentation"><a href="hotline_active_calls.php">Active Calls</a></li>
-            <li role="presentation"><a href="hotline_staff.php">Staff</a></li>
-            <li role="presentation"><a href="hotline_blocks.php">Blocks</a></li>
-            <li role="presentation"><a href="hotline_languages.php">Languages</a></li>
-            <li role="presentation" class="active"><a href="log.php?ph=<?php echo sms_getFirstHotline($hotline_number, $hotline, $error) ? urlencode($hotline_number) : '' ?>">Log</a></li>
-          </ul>
-          <br />
-
-          <h3 class="sub-header">Log</h3>
+        <h2 class="sub-header">Log</h2>
           <p>Click a phone number to view all communications with that number.  Click the response button or link to mark or
           unmark an item as responded to.</p>
           <form id="choose_number" action="log.php" method="GET" class="form-inline">

--- a/twin/incoming-sms.php
+++ b/twin/incoming-sms.php
@@ -49,7 +49,7 @@ if (sms_handleAdminText($from, $to, $body, $message, $error)) {
 	// no, process normally
 
 	// is this a broadcast text?
-	if ($to == $BROADCAST_CALLER_ID) {
+	if (in_array($to, $BROADCAST_CALLER_IDS)) {
 		processBroadcastText($from, $body, $message, $error);
 	}
 	

--- a/twin/incoming-voice.php
+++ b/twin/incoming-voice.php
@@ -8,7 +8,8 @@
 * 
 * Calls to the broadcast number will play recorded messages in each
 * language and hangup, if messages are set.  Otherwise, calls will be 
-* routed to the hotline.
+* routed to a hotline, if $BROADCAST_SEND_TO_HOTLINE is set.  Otherwise,
+* $HOTLINE_GOODBYE will be played, and the call will hangup.
 * 
 */
 

--- a/twin/incoming-voice.php
+++ b/twin/incoming-voice.php
@@ -30,13 +30,19 @@ if (!db_db_query($sql, $languages, $error)) {
 }
 
 $response = new Twilio\Twiml();
-// is this a broadcast text, and is a message set?
-if (($to == $BROADCAST_CALLER_ID) && count($BROADCAST_VOICE_MESSAGES) > 0) {
+// is this to a broadcast number, and is a message set?
+if (in_array($to, $BROADCAST_CALLER_IDS) && count($BROADCAST_VOICE_MESSAGES) > 0) {
 	// play broadcast messages in each language and hangup
 	foreach ($BROADCAST_VOICE_MESSAGES as $language_code => $message) {
 		sms_playOrSay($response, $message, $language_code);
 	}	
-} elseif (array_key_exists($to, $HOTLINES)) {
+} elseif (array_key_exists($to, $HOTLINES) || $BROADCAST_SEND_TO_HOTLINE) {
+	// calling from a non-hotline number?
+	if (!array_key_exists($to, $HOTLINES)) {
+		// yes, switch to the appropriate hotline
+		$to = $BROADCAST_SEND_TO_HOTLINE;
+	}
+	
 	// use hotline functionality
 	$hotline = $HOTLINES[$to];
 	
@@ -63,6 +69,9 @@ if (($to == $BROADCAST_CALLER_ID) && count($BROADCAST_VOICE_MESSAGES) > 0) {
 	$response->redirect('incoming-voice-dial.php?Digits=TIMEOUT',
 		array('method' => 'GET')
 	);
+} else {
+	// nothing defined, say goodbye
+	sms_playOrSay($response, $HOTLINE_GOODBYE);
 }
 
 echo $response;


### PR DESCRIPTION
Hi everyone,

I added support for multiple broadcast numbers, whether or not the Twilio Notify service is used.  An important change that must be made to the config.php file is that $BROADCAST_CALLER_ID has been removed, and is now an array of numbers called $BROADCAST_CALLER_IDS.  All this required changes to many parts of the codebase.

I also corrected a bug that we may not have thought about before.  When someone responds to a broadcast that requested a response that's limited by tags, we need to check to make sure they were part of that broadcast.

And finally I added a countdown timer that estimates how much time is left to send broadcast texts on Twilio's end.  This doesn't automatically refresh, but it would be easy to add some javascript to do this.

Thanks,
Alex
