### PR TITLE
Improvements to staff entry user interface, and minor bug fixes.

### DIFF
--- a/communications_export.php
+++ b/communications_export.php
@@ -4,32 +4,33 @@
 * Form to export communications to CSV file
 *
 * The export.php file performs the export.
-* 
+*
 * Variables:
 *   $export[]
 * 		'earliest' => Earliest date/time to include
 * 		'latest' => Latest date/time to include
 * 		'phone' => If set, limits the export to records to or from this number
+*       'type'' => If set, limits the export to this type of record
 */
-
+$export = array("earliest"=>"", "latest"=>"", "phone"=>"", "type"=>"");
 ?>
 	      <h3>Export to CSV</h2>
-		  <form class="form-inline" action="export.php" method="POST">
+		  <form class="form-inline" action="export.php?type=communications" method="POST">
 			<div class="form-group">
 			  <label for="export_earliest">Earliest: </label>
-			  <input type="text" class="form-control" name="export[earliest]" id="export_earliest" 
+			  <input type="text" class="form-control" name="export[earliest]" id="export_earliest"
 			         placeholder="<?php echo date("m/d/y") ?>"
 			         value="<?php echo $export['earliest'] ?>">
 			</div>
 			<div class="form-group">
 			  <label for="export_latest">Latest: </label>
-			  <input type="text" class="form-control" name="export[latest]" id="export_latest" 
+			  <input type="text" class="form-control" name="export[latest]" id="export_latest"
 			         placeholder="<?php echo date("m/d/y"); ?>"
 			         value="<?php echo $export['latest'] ?>">
 			</div>
 			<div class="form-group">
 			  <label for="export_phone">Limit to phone: </label>
-			  <input type="text" class="form-control" name="export[phone]" id="export_phone" 
+			  <input type="text" class="form-control" name="export[phone]" id="export_phone"
 			         placeholder="<?php echo sms_getFirstHotline($hotline_number, $hotline, $error) ? $hotline_number : $BROADCAST_CALLER_ID ?>"
 			         value="<?php echo $export['phone'] ?>">
 			</div>

--- a/communications_export.php
+++ b/communications_export.php
@@ -16,7 +16,7 @@ $export = array("earliest"=>"", "latest"=>"", "phone"=>"", "type"=>"");
 ?>
 	      <h3>Export to CSV</h2>
 	      <p class="help-block">Use <b>all_broadcast</b> as the phone number to include all broadcast numbers.</p>
-		  <form class="form-inline" action="export.php?type=communications" method="POST">
+	      <form class="form-inline" action="export.php?type=communications" method="POST">
 			<div class="form-group">
 			  <label for="export_earliest">Earliest: </label>
 			  <input type="text" class="form-control" name="export[earliest]" id="export_earliest"
@@ -31,9 +31,9 @@ $export = array("earliest"=>"", "latest"=>"", "phone"=>"", "type"=>"");
 			</div>
 			<div class="form-group">
 			  <label for="export_phone">Limit to phone: </label>
-			  <input type="text" class="form-control" name="export[phone]" id="export_phone" 
+			  <input type="text" class="form-control" name="export[phone]" id="export_phone"
 			         placeholder="<?php echo sms_getFirstHotline($hotline_number, $hotline, $error) ? $hotline_number : reset($BROADCAST_CALLER_IDS) ?>"
-			         value="<?php echo $export['phone'] ?>">			  
+			         value="<?php echo $export['phone'] ?>">
 			</div>
 			<div class="form-group">
 			  <label for="export_type">Type: </label>

--- a/export.php
+++ b/export.php
@@ -4,7 +4,7 @@
 * Export a communicatons log to a CSV file
 *
 * Show the latest calls and texts.
-* 
+*
 */
 
 require_once 'config.php';
@@ -12,14 +12,22 @@ require_once $LIB_BASE . 'lib_sms.php';
 
 db_databaseConnect();
 
+$type = $_REQUEST['type'];
 $export = $_REQUEST['export'];
 
-if (!exportToCsv($export, $error)) {
-	include 'header.php';
-?>
+if ($type == 'communications') {
+    $result = exportCommunicationsToCsv($export, $error);
+} elseif ($type == 'calltimes') {
+    $result = exportCallTimesToCsv($export, $error);
+} else {
+    $result = false;
+    $error = "Unrecognized export type \"".$type."\".";
+}
+if ($result == false) {
+    include 'header.php'; ?>
 <div class="alert alert-danger" role="alert"><?php echo $error ?></div>
-<?php	
-	include 'footer.php';
+<?php
+    include 'footer.php';
 }
 
 db_databaseDisconnect();
@@ -34,7 +42,7 @@ db_databaseDisconnect();
 * 	Content
 * 	Type
 * 	Responded
-* 
+*
 * @param array $export
 *	'earliest' => Earliest date/time to include
 * 	'latest' => Latest date/time to include
@@ -42,50 +50,117 @@ db_databaseDisconnect();
 * 	'type' => limit only to this type of record
 * @param string &$error
 *   An error if one occurred.
-*   
+*
 * @return bool
 *   True unless an error occurred
 */
-
-function exportToCsv($export, &$error)
+function exportCommunicationsToCsv($export, &$error)
 {
-	$error = '';
-	
-	// determine what to include
-	$earliest = $export['earliest'] ? strtotime($export['earliest']) : '';
-	$latest = $export['latest'] ? strtotime($export['latest']) : '';
-	$phone = trim($export['phone']);
-	if ($phone) {
-		if (!sms_normalizePhoneNumber($phone, $error)) {
-			return false;
-		}
-	}
-	$type = trim($export['type']);
+    $error = '';
 
-	// load the matching records
-	$sql = "SELECT communication_time,phone_from,phone_to,body,status,responded FROM communications WHERE ".
-		($earliest ? ("communication_time > '".addslashes(date("Y-m-d H:i:s", $earliest))."' AND ") : '') .
-		($latest ? ("communication_time < '".addslashes(date("Y-m-d H:i:s", $latest))."' AND ") : '') .
-		($phone ? ("(phone_from = '".addslashes($phone)."' OR phone_to = '".addslashes($phone)."') AND ") : '') .
-		($type ? ("status = '".addslashes($type)."' AND ") : '') .
-		" 1 ".
-		"ORDER BY communication_time DESC";
-	if (!db_db_query($sql, $comms, $error)) {
-		return false;
-	}
+    // determine what to include
+    $earliest = $export['earliest'] ? strtotime($export['earliest']) : '';
+    $latest = $export['latest'] ? strtotime($export['latest']) : '';
+    $phone = trim($export['phone']);
+    if ($phone) {
+        if (!sms_normalizePhoneNumber($phone, $error)) {
+            return false;
+        }
+    }
+    $type = trim($export['type']);
 
-	// output the data
-	header("Content-Type: text/csv");
-	header("Content-Disposition: attachment; filename=export-log.csv");
+    // load the matching records
+    $sql = "SELECT communication_time,phone_from,phone_to,body,status,responded FROM communications WHERE ".
+        ($earliest ? ("communication_time > '".addslashes(date("Y-m-d H:i:s", $earliest))."' AND ") : '') .
+        ($latest ? ("communication_time < '".addslashes(date("Y-m-d H:i:s", $latest))."' AND ") : '') .
+        ($phone ? ("(phone_from = '".addslashes($phone)."' OR phone_to = '".addslashes($phone)."') AND ") : '') .
+        ($type ? ("status = '".addslashes($type)."' AND ") : '') .
+        " 1 ".
+        "ORDER BY communication_time DESC";
+    if (!db_db_query($sql, $comms, $error)) {
+        return false;
+    }
 
-	$fp = fopen("php://output", "w");
-	fwrite($fp, "time,from,to,content,type,responded\n");
-	foreach ($comms as $row) {
-		fputcsv($fp, $row);
-	}
-	fclose($fp);
-	
-	return true;
+    // output the data
+    header("Content-Type: text/csv");
+    header("Content-Disposition: attachment; filename=export-log.csv");
+
+    $fp = fopen("php://output", "w");
+    fwrite($fp, "time,from,to,content,type,responded\n");
+    foreach ($comms as $row) {
+        fputcsv($fp, $row);
+    }
+    fclose($fp);
+
+    return true;
+}
+
+/**
+* Load the call times data and output it as a CSV file
+*
+* Export fields:
+* 	Date/time
+* 	From
+* 	To
+* 	Content
+* 	Type
+* 	Responded
+*
+* @param array $export
+*	'contact_id' => Identifier of the contact for which to export; if empty,
+*                   all contacts' call times are to be exported.
+* @param string &$error
+*   An error if one occurred.
+*
+* @return bool
+*   True unless an error occurred
+*/
+function exportCallTimesToCsv($export, &$error)
+{
+    $error = '';
+
+    // Determine what to include.
+    $contact_id = trim($export['contact_id']);
+    if ($contact_id) {
+        $sql = "SELECT * FROM contacts WHERE id = '".$contact_id."'";
+    } else {
+        $sql = "SELECT * FROM contacts ORDER BY contact_name";
+    }
+
+    // Write the headers and start the output file.
+    header("Content-Type: text/csv");
+    header("Content-Disposition: attachment; filename=export-log.csv");
+    $fp = fopen("php://output", "w");
+
+    // Get all the call times for the contact(s), and write them to
+    // the CSV file.
+    if (db_db_query($sql, $contacts, $error)) {
+        $call_times = array();
+        foreach ($contacts as $contact) {
+            $call_times = array();
+            $sql = "SELECT '".$contact['contact_name']."' AS name,' ".$contact['phone'].
+                    "' AS number, day, earliest, latest, language_id, ".
+                    "IF(receive_texts = 'y', 1, 0), IF(receive_calls = 'y', 1, 0), ".
+                    "IF(receive_call_answered_alerts = 'y', 1, 0) ".
+                    "FROM call_times WHERE contact_id='{$contact['id']}' AND enabled='y' ".
+                    "ORDER BY day, earliest, latest, language_id";
+            if (!db_db_query($sql, $call_times, $error)) {
+                echo $error;
+                break;
+            }
+            fwrite($fp, "name,number,day,earliest,latest,language_id,receive_texts,".
+                        "receive_calls,receive_call_answered_alerts\n");
+            foreach ($call_times as $row) {
+                fputcsv($fp, $row);
+            }
+        }
+    } else {
+        echo $error;
+    }
+
+    fclose($fp);
+
+    return ($error == '');
 }
 
 ?>

--- a/hotline_call_times_alpha.php
+++ b/hotline_call_times_alpha.php
@@ -64,19 +64,23 @@ foreach ($contacts as $contact) {
         <td><?php echo getContactNumber($contact['phone']); ?></td>
         <?php
 
-    // Allow removal of staff entry if all call time records are
-    // removed.
+    // Allow editing or removal of staff entry if there are no call time
+    // records, or the addition of a call time.
     if (count($call_times) == 0) {
         ?>
         <td colspan="5"></td><td>
+          <a href="hotline_staff.php?display_type=alphabetical&action=editstaffmodal&id=<?php
+                echo $contact['id'] ?>"
+                title="Edit this staff entry">
+            <span class="glyphicon glyphicon-user" aria-hidden="true"></span></a>
           <a href="hotline_staff.php?display_type=alphabetical&action=addcalltimemodal&id=<?php
                 echo $contact['id'] ?>"
                 title="Add a call time">
             <span class="glyphicon glyphicon-plus" aria-hidden="true"></span></a>
           <a href="hotline_staff.php?display_type=alphabetical&action=removestaff&id=<?php
                 echo $contact['id'] ?>"
-              onClick="return confirm('Are you sure you want to remove this staff entry?');"
-              title="Remove this staff entry">
+                onClick="return confirm('Are you sure you want to remove this staff entry?');"
+                title="Remove this staff entry">
             <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
         <?php
     } else {
@@ -162,8 +166,12 @@ foreach ($contacts as $contact) {
             // that have not changed can be output as blank table cells.
             $last_call_time = $call_time; ?>
         <td>
-          <a href="hotline_staff.php?display_type=alphabetical&action=addcalltimemodal&id=<?php
+          <a href="hotline_staff.php?display_type=alphabetical&action=editstaffmodal&id=<?php
                 echo $contact['id'] ?>"
+                title="Edit this staff entry">
+            <span class="glyphicon glyphicon-user" aria-hidden="true"></span></a>
+          <a href="hotline_staff.php?display_type=alphabetical&action=addcalltimemodal&id=<?php
+                echo $call_time['entry_id'] ?>"
                 title="Add a call time for this staff member">
             <span class="glyphicon glyphicon-plus" aria-hidden="true"></span></a>
           <a href="hotline_staff.php?display_type=alphabetical&action=editcalltimemodal&id=<?php
@@ -190,6 +198,14 @@ foreach ($contacts as $contact) {
     // Close the foreach loop; iteration over all the contacts is done.
 }
       ?>
+      <tr>
+        <td colspan="7"><i>New staff entry </i></td>
+        <td>
+          <a href="hotline_staff.php?display_type=alphabetical&action=addstaffmodal"
+                title="Add a new staff entry">
+            <span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span></a>
+        </td>
+      </tr>
     </tbody>
   </table>
 </div>

--- a/hotline_call_times_chrono.php
+++ b/hotline_call_times_chrono.php
@@ -84,7 +84,12 @@ if ($TEST_MODE) {
     // with the call times.
     if (count($call_times) == 0) {
         ?>
-        <div><br>There are no call times on record.<br><br></div>
+        <div><br>There are no call times on record.</div>
+        <div><br><i>Add new staff entry</i>
+          <a href="hotline_staff.php?display_type=alphabetical&action=addstaffmodal"
+                title="Add a new staff entry">
+            <span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span></a>
+        <br><br><br></div>
         <?php
     } else {
 
@@ -236,7 +241,7 @@ if ($TEST_MODE) {
               <tr>
                 <td colspan="7"><i>New staff entry </i></td>
                 <td>
-                  <a href="hotline_staff.php?display_type=chronological&action=addstaffmodal"
+                  <a href="hotline_staff.php?display_type=alphabetical&action=addstaffmodal"
                         title="Add a new staff entry">
                     <span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span></a>
                 </td>

--- a/hotline_call_times_chrono.php
+++ b/hotline_call_times_chrono.php
@@ -210,6 +210,10 @@ if ($TEST_MODE) {
 
             // Action buttons.?>
             <td>
+              <a href="hotline_staff.php?display_type=chronological&action=editstaffmodal&id=<?php
+                    echo $call_time['staff_id'] ?>"
+                    title="Edit this staff entry">
+                  <span class="glyphicon glyphicon-user" aria-hidden="true"></span></a>
               <a href="hotline_staff.php?display_type=chronological&action=addcalltimemodal&id=<?php
                     echo $call_time['staff_id'] ?>"
                     title="Add a call time for this staff member">
@@ -229,6 +233,14 @@ if ($TEST_MODE) {
         }
 
         // Finish the table.?>
+              <tr>
+                <td colspan="7"><i>New staff entry </i></td>
+                <td>
+                  <a href="hotline_staff.php?display_type=chronological&action=addstaffmodal"
+                        title="Add a new staff entry">
+                    <span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span></a>
+                </td>
+              </tr>
             </tbody>
           </table>
         </div>

--- a/hotline_staff.php
+++ b/hotline_staff.php
@@ -32,11 +32,16 @@ if (!$authorized) {
 
 // *** ACTIONS ***
 
-// Add or remove a staff member, or add, edit, or remove a call time, or put up
-// a modal dialog to allow the user to add a new call time or edit an existing
+// Add staff members and/or call times in CSV format, or add, edit, or remove a
+// staff member, or add, edit, or remove a call time, or put up a modal dialog
+// to allow the user to add a new staff member or call time or edit an existing
 // one, if any of these actions were requested.
-if ($action == 'add' && $authorized) {
-    addStaff($staff, $error, $success);
+if ($action == 'addascsv' && $authorized) {
+    addStaffAndOrCallTimesAsCsv($staff, $error, $success);
+} elseif ($action == 'addstaff' && $authorized) {
+    addOrEditStaff(false, $staff, $error, $success);
+} elseif ($action == 'editstaff' && $authorized) {
+    addOrEditStaff(true, $staff, $error, $success);
 } elseif ($action == 'removestaff' && $authorized) {
     removeStaff($id, $error, $success);
 } elseif ($action == 'addcalltime' && $authorized) {
@@ -45,6 +50,12 @@ if ($action == 'add' && $authorized) {
     editCallTime($call_time, $call_time_languages, $error, $success);
 } elseif ($action == 'removecalltime' && $authorized) {
     removeCallTime($id, $error, $success);
+} elseif ($action == 'addstaffmodal' && $authorized) {
+    $modal_action = "Add";
+    require 'hotline_staff_modal.php';
+} elseif ($action == 'editstaffmodal' && $authorized) {
+    $modal_action = "Edit";
+    require 'hotline_staff_modal.php';
 } elseif ($action == 'addcalltimemodal' && $authorized) {
     $modal_action = "Add";
     require 'hotline_call_times_modal.php';
@@ -139,10 +150,10 @@ if ($display_type == "chronological") {
 
           ?>
           <form id="text-controls" action="hotline_staff.php" method="POST">
-		    <input type="hidden" name="action" value="add">
+		    <input type="hidden" name="action" value="addascsv">
             <input type="hidden" name="display_type" value="<?php echo $display_type ?>">
 		    <div class="form-group">
-			  <label for="text-message">Add staff</label>
+			  <label for="text-message">Add staff and/or call times manually</label>
 			  <textarea class="form-control" name="staff" rows="3" cols="30"></textarea>
 			  <p class="help-block">
 			    <b>Format:</b> name, phone number, day, earliest time, latest time, language
@@ -153,24 +164,32 @@ if ($display_type == "chronological") {
 		    <button class="btn btn-success" id="button-text">Add</button>
 		  </form>
           <?php
+
+include 'hotline_staff_export.php';
+
 include 'footer.php';
 
 /**
-* Lock the call_times table and any associated tables, modifying the specified
-* error message to hold an error if a problem occurs.
+* Lock the contacts and call_times tables and any associated tables, modifying
+* the specified error message to hold an error if a problem occurs.
 *
 * @param string $staffLine
-*   Line that was being added as new staff and/or new time.
+*   Line that was being added as new staff and/or new time, if any.
 * @param string &$error
 *   Message to be modified to include any error that occurred, if an error
 *   occurs while attempting the lock.
 * @return bool
 *   True if the tables were locked, false otherwise.
 */
-function lockCallTimesTablesForStaffAddition($staffLine, &$error)
+function lockTablesForStaffChange($staffLine, &$error)
 {
-    if (!db_db_command("LOCK TABLES call_times WRITE, call_times AS t2 WRITE", $thisError)) {
-        $error .= "{$staff_line}: ".$thisError."<br />\n";
+    if (!db_db_command("LOCK TABLES contacts WRITE, call_times WRITE, ".
+                "call_times AS t2 WRITE, languages WRITE", $thisError)) {
+        if ($staff_line != "") {
+            $error .= "{$staff_line}: ".$thisError."<br />\n";
+        } else {
+            $error .= $thisError;
+        }
         return false;
     }
     return true;
@@ -180,26 +199,30 @@ function lockCallTimesTablesForStaffAddition($staffLine, &$error)
 * Unlock any locked tables, modifying the specified error message if any.
 *
 * @param string $staffLine
-*   Line that was being added as new staff and/or new time.
+*   Line that was being added as new staff and/or new time, if any.
 * @param string &$error
 *   Message to be modified to include any error that occurred, if an error
 *   occurs while attempting the unlock.
 * @return bool
 *   True if the tables were unlocked, false otherwise.
 */
-function unlockTablesForStaffAddition($staffLine, &$error)
+function unlockTablesForStaffChange($staffLine, &$error)
 {
     if (!db_db_command("UNLOCK TABLES", $thisError)) {
-        $error .= "{$staff_line}: ".$thisError."<br />\n";
+        if ($staff_line != "") {
+            $error .= "{$staff_line}: ".$thisError."<br />\n";
+        } else {
+            $error .= $thisError;
+        }
         return false;
     }
     return true;
 }
 
 /**
-* Add staff to the database
+* Add staff and/or call times to the database, with the input being in CSV format.
 *
-* Each entry is separated by a newline.  Format:
+* Each entry is separated by a newline. Format:
 *    name,phone number,day,earliest time,latest time,language id,texts (0 or 1).
 *
 * @param array $staff
@@ -212,7 +235,7 @@ function unlockTablesForStaffAddition($staffLine, &$error)
 * @return bool
 *   True if any staff were provided.
 */
-function addStaff($staff, &$error, &$message)
+function addStaffAndOrCallTimesAsCsv($staff, &$error, &$message)
 {
     $error = '';
     $message = '';
@@ -255,14 +278,20 @@ function addStaff($staff, &$error, &$message)
             continue;
         }
 
-        // is this number in the database already?
+        // Lock the tables.
+        if (!lockTablesForStaffChange($staff_line, $error)) {
+            continue;
+        }
+
+        // See if this number is not already in the database.
         $sql = "SELECT * FROM contacts WHERE phone='".addslashes($staff_array[1])."'";
         if (!db_db_getrow($sql, $contact, $db_error)) {
             $error .= "{$staff_line}: {$db_error}<br />\n";
             continue;
         }
         if ($contact['id']) {
-            // it's already in the database, update the name
+
+            // Since it is already in the database, update the name.
             $sql = "UPDATE contacts SET contact_name='".addslashes(trim($staff_array[0]))."' ".
                 "WHERE id='{$contact['id']}'";
             if (!db_db_command($sql, $db_error)) {
@@ -270,14 +299,16 @@ function addStaff($staff, &$error, &$message)
                 continue;
             }
         } else {
-            // it's not in the database, add it
+
+            // Since it is not in the database, add it.
             $sql = "INSERT INTO contacts SET contact_name='".addslashes(trim($staff_array[0]))."',".
                 "phone='".addslashes($staff_array[1])."'";
             if (!db_db_command($sql, $db_error)) {
                 $error .= "{$staff_line}: {$db_error}<br />\n";
                 continue;
             }
-            // retrieve the newly added record
+
+            // Retrieve the newly added record.
             $sql = "SELECT * FROM contacts WHERE phone='".addslashes($staff_array[1])."'";
             if (!db_db_getrow($sql, $contact, $db_error)) {
                 $error .= "{$staff_line}: {$db_error}<br />\n";
@@ -285,7 +316,7 @@ function addStaff($staff, &$error, &$message)
             }
         }
 
-        // is a day provided?
+        // See if a day is provided.
         if (isset($staff_array[2]) && trim($staff_array[2])) {
             // provide defaults
             if (!$staff_array[3]) {
@@ -313,16 +344,18 @@ function addStaff($staff, &$error, &$message)
                 $staff_array[8] = 0;
             }
 
-            // get language_id from the language_keypress
+            // Ensure at least one of the received types is specified.
+            if (!$staff_array[6] && !$staff_array[7] && !$staff_array[8]) {
+                $error .= "{$staff_line}: No 'received type' (texts, ".
+                        "calls, or call answered alerts) specified.<br />\n";
+                continue;
+            }
+
+            // Get language_id from the language_keypress
             $language_id = "1";
             $sql = "SELECT id FROM languages WHERE keypress='". addslashes($staff_array[5]) . "'";
             if (!db_db_getone($sql, $language_id, $db_error)) {
                 $error .= "{$staff_line}: {$db_error}<br />\n";
-                continue;
-            }
-
-            // Lock the tables.
-            if (!lockCallTimesTablesForStaffAddition($staff_line, $error)) {
                 continue;
             }
 
@@ -342,14 +375,14 @@ function addStaff($staff, &$error, &$message)
                 addslashes($language_id)."')";
             if (!db_db_getone($query, $results, $thisError)) {
                 $error .= "{$staff_line}: {$thisError}<br />\n";
-                unlockTablesForStaffAddition($staff_line, $error);
+                unlockTablesForStaffChange($staff_line, $error);
                 continue;
             }
             if ($results) {
                 $thisError = "The call time record could not be added because it ".
                         "is a duplicate of an existing entry.";
                 $error .= "{$staff_line}: {$thisError}<br />\n";
-                unlockTablesForStaffAddition($staff_line, $error);
+                unlockTablesForStaffChange($staff_line, $error);
                 continue;
             }
 
@@ -365,13 +398,13 @@ function addStaff($staff, &$error, &$message)
                 $receive_call_answered_alerts."' LIMIT 1";
             if (!db_db_getone($query, $entryIdentifier, $thisError)) {
                 $error .= "{$staff_line}: {$thisError}<br />\n";
-                unlockTablesForStaffAddition($staff_line, $error);
+                unlockTablesForStaffChange($staff_line, $error);
                 continue;
             }
             if (!$entryIdentifier) {
                 if (!getNextAvailableEntryIdentifier($entryIdentifier, $thisError)) {
                     $error .= "{$staff_line}: {$thisError}<br />\n";
-                    unlockTablesForStaffAddition($staff_line, $error);
+                    unlockTablesForStaffChange($staff_line, $error);
                     continue;
                 }
             }
@@ -390,21 +423,132 @@ function addStaff($staff, &$error, &$message)
             if (!db_db_command($sql, $db_error)) {
                 $error .= "{$staff_line}: {$db_error}<br />\n";
             }
-
-            // Unlock the tables.
-            unlockTablesForStaffAddition($staff_line, $error);
         }
 
-        // import successful
+        // Unlock the tables.
+        unlockTablesForStaffChange($staff_line, $error);
+
+        // The import was successful.
         $success_count++;
     }
 
-    // report on the status of the import
+    // Report on the status of the import.
     $error_count = count($staff_lines) - $success_count;
     $message = "Imported {$success_count} staff entries successfully. ";
     if ($error_count) {
         $message .= "{$error_count} staff entries had errors.";
     }
+
+    return true;
+}
+
+/**
+* Add or edit a staff entry to the database.
+*
+* Data is passed from a modal form.
+*
+* @param bool edit
+*   Flag indicating whether editing or adding.
+* @param array $contact
+*   Contact form data.  Contains the following keys:
+*       'id' => Identifier of the contact (only provided if editing).
+*		'contact_name' => Contact name.
+* 		'phone' => Contact phone number.
+* @param string &$error
+*   Errors if any occurred.
+* @param string &$message
+*   An informational message if appropriate.
+* @return bool
+*   True unless an error occurred.
+*/
+function addOrEditStaff($edit, $contact, &$error, &$message)
+{
+    $error = '';
+    $message = '';
+
+    // Lock the tables.
+    $beingInserted = "";
+    if (!lockTablesForStaffChange($beingInserted, $db_error)) {
+        $error = "Error while locking tables: ".$db_error;
+        return false;
+    }
+
+    // Make sure the number is in E164 format, and that it is not already
+    // in the database.
+    $action = ($edit ? "edited" : "added");
+    $other = ($edit ? "another" : "an");
+    if (!sms_normalizePhoneNumber($contact['phone'], $error)) {
+        $error = "The staff entry could not be ".$action." because the ".
+                "specified phone number is invalid.";
+        unlockTablesForStaffChange($beingInserted, $db_error);
+        return false;
+    }
+    $sql = "SELECT * FROM contacts WHERE phone='".addslashes($contact['phone'])."'";
+    if ($edit) {
+        $sql .= " AND NOT id=".$contact['id'];
+    }
+    if (!db_db_getrow($sql, $existingContact, $db_error)) {
+        $error = "Error while looking up the provided phone number: ".$db_error;
+        unlockTablesForStaffChange($beingInserted, $db_error);
+        return false;
+    }
+    if ($existingContact['id']) {
+        $error = "The staff entry could not be ".$action." because the ".
+                "specified phone number is already assigned to ".$other." ".
+                "existing staff entry.";
+        unlockTablesForStaffChange($beingInserted, $db_error);
+        return false;
+    }
+
+    // Ensure that a valid name was specified, and that it is not already
+    // in the database.
+    $contactName = trim($contact['contact_name']);
+    if (!$contactName) {
+        $error = "The staff entry could not be ".$action." because no ".
+                "name was specified.";
+        unlockTablesForStaffChange($beingInserted, $db_error);
+        return false;
+    }
+    $sql = "SELECT * FROM contacts WHERE contact_name='".addslashes($contactName)."'";
+    if ($edit) {
+        $sql .= " AND NOT id=".$contact['id'];
+    }
+    if (!db_db_getrow($sql, $existingContact, $db_error)) {
+        $error = "Error while looking up the provided name: ".$db_error;
+        unlockTablesForStaffChange($beingInserted, $db_error);
+        return false;
+    }
+    if ($existingContact['id']) {
+        $error = "The staff entry could not be ".$action." because the ".
+                "specified name is already assigned to ".$other." existing ".
+                "staff entry.";
+        unlockTablesForStaffChange($beingInserted, $db_error);
+        return false;
+    }
+
+    // Insert the new entry into the table if adding, or update the existing
+    // entry if editing.
+    if ($edit) {
+        $sql = "UPDATE contacts SET contact_name='".addslashes($contactName).
+            "', phone='".addslashes($contact['phone'])."' WHERE id=".$contact['id'];
+    } else {
+        $sql = "INSERT INTO contacts SET contact_name='".addslashes($contactName)."',".
+            "phone='".addslashes($contact['phone'])."'";
+    }
+    if (!db_db_command($sql, $db_error)) {
+        $error = "Error while ".($edit ? "inserting" : "updating").
+                " the staff entry: ".$db_error;
+        unlockTablesForStaffChange($beingInserted, $db_error);
+        return false;
+    }
+
+    // Unlock the tables.
+    if (!unlockTablesForStaffChange($beingInserted, $db_error)) {
+        $error = "Error while unlocking tables: ".$db_error;
+        return false;
+    }
+
+    $message = "The staff entry was ".$action.".";
 
     return true;
 }
@@ -426,19 +570,38 @@ function addStaff($staff, &$error, &$message)
 */
 function removeStaff($id, &$error, &$message)
 {
-    // are all call time entries removed?
+
+    // Lock the tables.
+    $beingRemoved = "";
+    if (!lockTablesForStaffChange($beingRemoved, $db_error)) {
+        $error = "Error while locking tables: ".$db_error;
+        return false;
+    }
+
+    // Ensure that all call time entries for this staff entry have been removed.
     $sql = "SELECT COUNT(*) FROM call_times WHERE contact_id='".addslashes($id)."'";
-    if (!db_db_getone($sql, $call_time_count, $error)) {
+    if (!db_db_getone($sql, $call_time_count, $db_error)) {
+        $error = "Error while checking for call time entries: ".$db_error;
+        unlockTablesForStaffChange($beingRemoved, $db_error);
         return false;
     }
     if ($call_time_count) {
         $error = "Please remove the call time entries first.";
+        unlockTablesForStaffChange($beingRemoved, $db_error);
         return false;
     }
 
-    // delete the staff entry
+    // Delete the staff entry.
     $sql = "DELETE FROM contacts WHERE id='".addslashes($id)."'";
-    if (!db_db_command($sql, $error)) {
+    if (!db_db_command($sql, $db_error)) {
+        $error = "Error while deleting staff entry: ".$db_error;
+        unlockTablesForStaffChange($beingRemoved, $db_error);
+        return false;
+    }
+
+    // Unlock the tables.
+    if (!unlockTablesForStaffChange($beingRemoved, $db_error)) {
+        $error = "Error while unlocking tables: ".$db_error;
         return false;
     }
 

--- a/hotline_staff_export.php
+++ b/hotline_staff_export.php
@@ -1,0 +1,36 @@
+<?php
+/**
+* @file
+* Form to export staff call times to CSV file
+*
+* The export.php file performs the export.
+*
+* Variables:
+*   $export[]
+* 		'contact_id' => Identifier of the contact for which to export call times.
+*                       If empty, all contacts' call times should be exported.
+*/
+$export = array("contact_id"=>"");
+
+// Query the database for the contacts.
+if (!db_db_query("SELECT * FROM contacts ORDER BY contact_name", $contacts, $error)) {
+    echo $error;
+}
+?>
+	      <h3>Export to CSV</h2>
+		  <form class="form-inline" action="export.php?type=calltimes" method="POST">
+			<div class="form-group">
+			  <label for="export_type">Limit to staff member: </label>
+			  <select class="form-control" name="export[contact_id]" id="export_contact_id">
+				<option value="">(all staff)</option>
+                <?php
+foreach ($contacts as $contact) {
+    ?>
+                <option value="<?php echo $contact['id'] ?>"><?php echo $contact['contact_name'] ?></option>
+                <?php
+}
+                ?>
+			  </select>
+			</div>
+			<button type="submit" class="btn btn-default">Export</button>
+		  </form>

--- a/hotline_staff_modal.php
+++ b/hotline_staff_modal.php
@@ -1,0 +1,83 @@
+<?php
+/**
+* @file
+* Staff modal dialog, for adding or editing staff entries.
+*
+* This file is to be included in a page; it does not work as a standalone
+* page.
+*/
+
+// Set up the initial values to be displayed by the dialog differently
+// depending upon whether a new staff entry is being added, or an existing
+// one is being edited.
+if ($modal_action == "Add") {
+
+    // Initialize a new staff entry array.
+    $staff = array(
+        'contact_name' => "",
+        'phone' => ""
+    );
+} else {
+
+    // Get the staff entry as a record.
+    $sql = "SELECT id, contact_name, phone FROM contacts ".
+            "WHERE id='".addslashes($id)."'";
+    db_db_getrow($sql, $staff, $error);
+}
+
+// Create the modal dialog.
+?>
+
+<div class="modal show" tabindex="-1" role="dialog">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <form id="modal-staff" action="hotline_staff.php" method="POST">
+        <input type="hidden" name="action" value="<?php
+                echo strtolower($modal_action) ?>staff">
+        <input type="hidden" name="display_type" value="<?php echo $display_type ?>">
+        <?php
+
+if ($modal_action == "Edit") {
+    ?>
+
+        <input type="hidden" name="staff[id]"
+                value="<?php echo $staff['id'] ?>">
+
+        <?php
+}
+
+        ?>
+        <div class="modal-header">
+          <a class="btn close"
+                href="hotline_staff.php?display_type=<?php echo $display_type ?>"
+                role="button" aria-label="Close"><span aria-hidden="true">&times;</span></a>
+          <h4 class="modal-title">
+            <strong>
+              <?php echo $modal_action ?> staff entry
+            </strong>
+          </h4>
+        </div>
+        <div class="modal-body">
+          <div class="form-group">
+            <label for="staff_name">Name</label>
+            <input type="text" class="form-control" id="staff_name"
+                    name="staff[contact_name]"
+                    value="<?php echo $staff['contact_name'] ?>">
+          </div>
+          <div class="form-group">
+            <label for="staff_phone">Phone</label>
+            <input type="text" class="form-control" id="staff_phone"
+                    name="staff[phone]"
+                    value="<?php echo $staff['phone'] ?>">
+          </div>
+        </div>
+        <div class="modal-footer">
+          <a class="btn btn-default"
+                href="hotline_staff.php?display_type=<?php echo $display_type ?>"
+                role="button">Close</a>
+          <button type="submit" class="btn btn-primary"><?php echo $modal_action ?></button>
+        </div>
+      </form>
+    </div><!-- /.modal-content -->
+  </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->


### PR DESCRIPTION
(1) Added a modal dialog used to add or edit staff entries. These are triggered by buttons in the "sort by name" version of the hotline staff page: a button in each row allowing editing of existing staff entries, and a button at the bottom of the table allowing addition of new staff entries.

(2) Added CSV export to the bottom of the hotline staff page, allowing staff and call time entries to be exported in the same format as they are imported in the text field right above it.

(3) Fixed a bug that allowed the addition of call times via CSV import that included no 'receive type' (texts, calls, or alerts).

(4) Changed locking of tables to be more comprehensive when adding staff and/or call time entries via CSV import, or when deleting staff.