### PR TITLE
Fixed bug from previously merged pull reques.t

### DIFF
--- a/hotline_call_times_alpha.php
+++ b/hotline_call_times_alpha.php
@@ -171,7 +171,7 @@ foreach ($contacts as $contact) {
                 title="Edit this staff entry">
             <span class="glyphicon glyphicon-user" aria-hidden="true"></span></a>
           <a href="hotline_staff.php?display_type=alphabetical&action=addcalltimemodal&id=<?php
-                echo $call_time['entry_id'] ?>"
+                echo $contact['id'] ?>"
                 title="Add a call time for this staff member">
             <span class="glyphicon glyphicon-plus" aria-hidden="true"></span></a>
           <a href="hotline_staff.php?display_type=alphabetical&action=editcalltimemodal&id=<?php


### PR DESCRIPTION
Fixed bug from the previous merged pull request that caused the wrong
contact identifier to be referenced when adding a new call time for a
staff member from the sorted-by-name table holding staff call times.