### PR TITLE
Enhancements to shift change reminders via text messages

### DIFF
--- a/config_sample.php
+++ b/config_sample.php
@@ -55,15 +55,24 @@ $BROADCAST_VOICE_MESSAGES = array(
 
 );
 
-// Message to be sent via text to staff members who are about to start their
-// shifts. The time at which the shift is to start will be appended to this
-// string to form the message.
-$STAFF_REMINDER_START_SHIFT = "Reminder: Your hotline staffing shift begins at ";
+// Descriptions of the different types of incoming communications for which staff
+// members may be scheduled.
+$RECEIVE_TEXTS_DESCRIPTION = "texts";
+$RECEIVE_CALLS_DESCRIPTION = "calls";
+$RECEIVE_CALL_ANSWERED_ALERTS_DESCRIPTION = "call-answered alerts";
 
-// Message to be sent via text to staff members who are about to end their
-// shifts. The time at which the shift is to end will be appended to this
-// string to form the message.
-$STAFF_REMINDER_END_SHIFT = "Reminder: Your hotline staffing shift ends at ";
+// Substrings used to compose messages to be sent via text to staff members who are
+// about to start or end their shifts. To $STAFF_REMINDER_SHIFT_CHANGE_MESSAGE_PREFIX
+// is appended the type(s) of incoming communications ($RECEIVE_TEXTS_DECRIPTION,
+// $RECEIVE_CALLS_DECRIPTION, and/or $RECEIVE_CALL_ANSWERED_ALERTS_DECRIPTION) as a
+// comma-separated list for which the staff member is scheduled, then the
+// $STAFF_REMINDER_SHIFT_START_DESCRIPTION or $STAFF_REMINDER_SHIFT_END_DESCRIPTION as
+// appropriate, then the time at which the shift change is to occur, and finally the
+// $STAFF_REMINDER_SHIFT_CHANGE_MESSAGE_SUFFIX.
+$STAFF_REMINDER_SHIFT_CHANGE_MESSAGE_PREFIX = "Reminder: Your hotline staffing shift (";
+$STAFF_REMINDER_SHIFT_START_DESCRIPTION = ") begins at ";
+$STAFF_REMINDER_SHIFT_END_DESCRIPTION = ") ends at ";
+$STAFF_REMINDER_SHIFT_CHANGE_MESSAGE_SUFFIX = ".";
 
 // If set, callers to the broadcast numbers will be redirected to this hotline.
 // Don't set this and $BROADCAST_VOICE_MESSAGES

--- a/database_schema.sql
+++ b/database_schema.sql
@@ -72,7 +72,8 @@ CREATE TABLE `call_times` (
   `receive_calls` enum('y','n') NOT NULL DEFAULT 'y',
   `receive_call_answered_alerts` enum('y','n') NOT NULL DEFAULT 'n',
   `language_id` int(11) UNSIGNED NOT NULL DEFAULT '0',
-  `enabled` enum('y','n') NOT NULL DEFAULT 'y'
+  `enabled` enum('y','n') NOT NULL DEFAULT 'y',
+  `remind` enum('y','n') NOT NULL DEFAULT 'y'
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 COMMENT='Defines days and times that a volunteer will be called.';
 
 -- --------------------------------------------------------

--- a/database_update.php
+++ b/database_update.php
@@ -178,6 +178,31 @@ function ensureDatabaseIsUpToDate()
                 "added and populated for all existing entries.");
     }
 
+    // Determine whether or not the remind column exists in the table, and
+    // if it does not, create it and populate it.
+    $query = "SHOW COLUMNS FROM call_times LIKE 'remind'";
+    if (!db_db_getone($query, $results, $error)) {
+        unlockTablesForDatabaseUpdate("The call times table could not be checked ".
+                "for the remind column's existence because a database error ".
+                "occurred: ".$error);
+        return;
+    }
+    if (!$results) {
+
+        // Add the column to the table.
+        $sql = "ALTER TABLE call_times ADD remind enum('y','n') NOT NULL ".
+                "DEFAULT 'y' AFTER enabled";
+        if (!db_db_command($sql, $error)) {
+            unlockTablesForDatabaseUpdate("The call times table could not have ".
+                    "the remind column added because a database error occurred: ".
+                    $error);
+            return;
+        }
+
+        displaySuccess("The call times table had the remind column added ".
+                "and populated for all existing entries.");
+    }
+
     // Unlock the table.
     if (!unlockTablesForDatabaseUpdate(null)) {
         return;

--- a/hotline_call_times_modal.php
+++ b/hotline_call_times_modal.php
@@ -27,7 +27,8 @@ if ($modal_action == "Add") {
         'language_ids' => null,
         'receive_texts' => "y",
         'receive_calls' => "y",
-        'receive_call_answered_alerts' => "n"
+        'receive_call_answered_alerts' => "n",
+        'remind' => 'y'
     );
 } else {
 
@@ -35,10 +36,10 @@ if ($modal_action == "Add") {
     // listed sequentially.
     $sql = "SELECT entry_id, contact_id, day, earliest, latest, ".
             "receive_texts, receive_calls, receive_call_answered_alerts, ".
-            "GROUP_CONCAT(language_id) AS language_ids FROM call_times ".
+            "GROUP_CONCAT(language_id) AS language_ids, remind FROM call_times ".
             "WHERE entry_id='".addslashes($id)."' GROUP BY entry_id, ".
             "contact_id, day, earliest, latest, receive_texts, ".
-            "receive_calls, receive_call_answered_alerts";
+            "receive_calls, receive_call_answered_alerts, remind";
     db_db_getrow($sql, $call_time, $error);
     $call_time['earliest'] = getDisplayableTime($call_time['earliest']);
     $call_time['latest'] = getDisplayableTime($call_time['latest']);
@@ -154,6 +155,14 @@ if (($call_time['language_ids'] == null) || in_array($language['id'], $call_time
                     <?php
                         echo($call_time['receive_call_answered_alerts'] == "y" ? " checked" : "")
                     ?>> call answered alerts
+            </label>
+          </div>
+          <div class="form-group">
+            <label class="checkbox-inline">
+              <input type="checkbox" id="calltime_remind" name="call_time[remind]"
+                    <?php
+                        echo($call_time['remind'] == "y" ? " checked" : "")
+                    ?>> Remind staff member via text when shift starts and ends
             </label>
           </div>
         </div>

--- a/hotline_call_times_utils.php
+++ b/hotline_call_times_utils.php
@@ -496,6 +496,8 @@ function addCallTime($call_time, $call_time_languages, &$error, &$message)
 
     // Add one call_times record for each language, with all records having
     // the same entry identifier.
+    $remind = (isset($call_time['remind']) &&
+            ($call_time['remind'] == 'on') ? "y" : "n");
     foreach ($languages as $language) {
         $sql = "INSERT INTO call_times SET ".
             "entry_id='".addslashes($entryIdentifier)."',".
@@ -506,7 +508,8 @@ function addCallTime($call_time, $call_time_languages, &$error, &$message)
             "language_id='".addslashes($language)."',".
             "receive_texts='".$receive_texts."',".
             "receive_calls='".$receive_calls."',".
-            "receive_call_answered_alerts='".$receive_call_answered_alerts."'";
+            "receive_call_answered_alerts='".$receive_call_answered_alerts."',".
+            "remind='".$remind."'";
         if (!db_db_command($sql, $error)) {
             $error = "The call time entry could not be fully added due to ".
                     "a database error: ".$error;
@@ -649,6 +652,8 @@ function editCallTime($call_time, $call_time_languages, &$error, &$message)
 
     // Add one call_times record for each language, with all records having
     // the same entry identifier.
+    $remind = (isset($call_time['remind']) &&
+            ($call_time['remind'] == 'on') ? "y" : "n");
     foreach ($languages as $language) {
         $sql = "INSERT INTO call_times SET ".
             "entry_id='".addslashes($call_time['entry_id'])."',".
@@ -659,7 +664,8 @@ function editCallTime($call_time, $call_time_languages, &$error, &$message)
             "language_id='".addslashes($language)."',".
             "receive_texts='".$receive_texts."',".
             "receive_calls='".$receive_calls."',".
-            "receive_call_answered_alerts='".$receive_call_answered_alerts."'";
+            "receive_call_answered_alerts='".$receive_call_answered_alerts."',".
+            "remind='".$remind."'";
         if (!db_db_command($sql, $error)) {
             $error = "The call time entry could not be fully updated due to ".
                     "a database error: ".$error;

--- a/lib/lib_db.php
+++ b/lib/lib_db.php
@@ -74,7 +74,8 @@ function db_databaseDisconnect()
 
 function db_error($description, $severity = 'error')
 {
-    $admin_user = $_SERVER['PHP_AUTH_USER'] ? $_SERVER['PHP_AUTH_USER'] : $_SERVER['REMOTE_USER'];
+    $admin_user = isset($_SERVER['PHP_AUTH_USER']) ? $_SERVER['PHP_AUTH_USER'] :
+            (isset($_SERVER['REMOTE_USER']) ? $_SERVER['REMOTE_USER'] : $_SERVER['USER']);
 
     $sql = "INSERT INTO errors SET ".
         "severity='".trim(addslashes($severity))."',".

--- a/lib/lib_sms.php
+++ b/lib/lib_sms.php
@@ -168,25 +168,11 @@ function sms_getShiftChangeContacts(&$contacts, $day, $startTime, $endTime, $bou
             $otherContactNamesAndCommTypeFlags[sms_getCallTimeEntryAsKey($contact)] = true;
         }
 
-
-        echo "Base contacts to be checked:\n";
-        foreach ($contactShiftIndicesToCheck as $index) {
-            $contact = $contacts[$index];
-            echo "    ".sms_getCallTimeEntryAsKey($contact).": ".$contact['earliest'].
-                    " to ".$contact['latest']."\n";
-        }
-        echo "Other contacts against which to check:\n";
-        foreach ($otherContactNamesAndCommTypeFlags as $key => $value) {
-            echo "    ".$key."\n";
-        }
-
-
-        echo "Contact to be removed as a result:\n";
+        // Prune any shifts that are contiguous with shifts at the
+        // other side of midnight, as compiled above.
         foreach ($contactShiftIndicesToCheck as $index) {
             $contact = $contacts[$index];
             if (isset($otherContactNamesAndCommTypeFlags[sms_getCallTimeEntryAsKey($contact)])) {
-                echo "    ".sms_getCallTimeEntryAsKey($contact).": ".$contact['earliest'].
-                        " to ".$contact['latest']."\n";
                 unset($contacts[$index]);
             }
         }


### PR DESCRIPTION
NOTE: Prior to using this changeset, someone must navigate to the database_update.php page, since a new column has been added to the call_times database table (see below).

Removed code that tried to be clever about pruning out shift change messages that are duplicates of one another (e.g. person X has a shift for texts and calls starting at 12:10am). The idea was to avoid annoying duplicates, but it was pointed out at the last tech team meeting that duplicate messages mean duplicate entries in the database, which should be cleaned up, so staff members will now see such duplicates if shifts that have parameters in common exist.

Added the type(s) of relevant shift (texts, calls, and/or call alert messages) to the notification sent via text to the staff member, so that the latter will know what they're signed up to handle.

Added weeding out of notifications that should not be sent out because one shift is ending at 11:59:59pm and the next one, identical in terms of the staff member's name and the types of incoming info they are to handle, is starting at 12:00am the next day. These are used because entries cannot span multiple days, so if for example a staff member is on duty from 8:00pm to 4:00am, this has to be entered into the database as two shifts, one lasting until midnight, the next starting at midnight. Such cases will no longer result in the staff member being told that they have  shift ending at 11:59pm and then another one starting at 12:00am. (Note that if the type of incoming communications handled is different between the two entries, then the staff member will be notified, as those are two different shifts.)

Added a new column to the call_times table in the database, "remind", that indicates whether or not a shift's start or end is to generate a reminder text message. This defaults to true. The add/edit call time modal dialog has been changed to include a checkbox for this parameter, so it can be toggled for individual shifts easily.